### PR TITLE
Improve weather and profile handling

### DIFF
--- a/docs/fig/250224_segmentation_algorithms.svg
+++ b/docs/fig/250224_segmentation_algorithms.svg
@@ -1,0 +1,2932 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="610.60125pt" height="410.012964pt" viewBox="0 0 610.60125 410.012964" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:date>2025-02-20T16:58:06.748352</dc:date>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.6.3, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 410.012964 
+L 610.60125 410.012964 
+L 610.60125 0 
+L 0 0 
+z
+" style="fill: #ffffff"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 45.40125 356.477812 
+L 603.40125 356.477812 
+L 603.40125 23.837812 
+L 45.40125 23.837812 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="patch_3">
+    <path d="M 70.764886 356.477812 
+L 81.333068 356.477812 
+L 81.333068 356.477812 
+L 70.764886 356.477812 
+z
+" clip-path="url(#p7de345fdc2)" style="fill: #d3d3d3"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 81.333068 356.477812 
+L 91.90125 356.477812 
+L 91.90125 356.477812 
+L 81.333068 356.477812 
+z
+" clip-path="url(#p7de345fdc2)" style="fill: #d3d3d3"/>
+   </g>
+   <g id="patch_5">
+    <path d="M 91.90125 356.477812 
+L 102.469432 356.477812 
+L 102.469432 356.477812 
+L 91.90125 356.477812 
+z
+" clip-path="url(#p7de345fdc2)" style="fill: #d3d3d3"/>
+   </g>
+   <g id="patch_6">
+    <path d="M 102.469432 356.477812 
+L 113.037614 356.477812 
+L 113.037614 356.477812 
+L 102.469432 356.477812 
+z
+" clip-path="url(#p7de345fdc2)" style="fill: #d3d3d3"/>
+   </g>
+   <g id="patch_7">
+    <path d="M 113.037614 356.477812 
+L 123.605795 356.477812 
+L 123.605795 353.521669 
+L 113.037614 353.521669 
+z
+" clip-path="url(#p7de345fdc2)" style="fill: #d3d3d3"/>
+   </g>
+   <g id="patch_8">
+    <path d="M 123.605795 356.477812 
+L 134.173977 356.477812 
+L 134.173977 353.521669 
+L 123.605795 353.521669 
+z
+" clip-path="url(#p7de345fdc2)" style="fill: #d3d3d3"/>
+   </g>
+   <g id="patch_9">
+    <path d="M 134.173977 356.477812 
+L 144.742159 356.477812 
+L 144.742159 353.521669 
+L 134.173977 353.521669 
+z
+" clip-path="url(#p7de345fdc2)" style="fill: #d3d3d3"/>
+   </g>
+   <g id="patch_10">
+    <path d="M 144.742159 356.477812 
+L 155.310341 356.477812 
+L 155.310341 353.521669 
+L 144.742159 353.521669 
+z
+" clip-path="url(#p7de345fdc2)" style="fill: #d3d3d3"/>
+   </g>
+   <g id="patch_11">
+    <path d="M 155.310341 356.477812 
+L 165.878523 356.477812 
+L 165.878523 322.974858 
+L 155.310341 322.974858 
+z
+" clip-path="url(#p7de345fdc2)" style="fill: #d3d3d3"/>
+   </g>
+   <g id="patch_12">
+    <path d="M 165.878523 356.477812 
+L 176.446705 356.477812 
+L 176.446705 322.974858 
+L 165.878523 322.974858 
+z
+" clip-path="url(#p7de345fdc2)" style="fill: #d3d3d3"/>
+   </g>
+   <g id="patch_13">
+    <path d="M 176.446705 356.477812 
+L 187.014886 356.477812 
+L 187.014886 322.974858 
+L 176.446705 322.974858 
+z
+" clip-path="url(#p7de345fdc2)" style="fill: #d3d3d3"/>
+   </g>
+   <g id="patch_14">
+    <path d="M 187.014886 356.477812 
+L 197.583068 356.477812 
+L 197.583068 322.974858 
+L 187.014886 322.974858 
+z
+" clip-path="url(#p7de345fdc2)" style="fill: #d3d3d3"/>
+   </g>
+   <g id="patch_15">
+    <path d="M 197.583068 356.477812 
+L 208.15125 356.477812 
+L 208.15125 314.106428 
+L 197.583068 314.106428 
+z
+" clip-path="url(#p7de345fdc2)" style="fill: #d3d3d3"/>
+   </g>
+   <g id="patch_16">
+    <path d="M 208.15125 356.477812 
+L 218.719432 356.477812 
+L 218.719432 314.106428 
+L 208.15125 314.106428 
+z
+" clip-path="url(#p7de345fdc2)" style="fill: #d3d3d3"/>
+   </g>
+   <g id="patch_17">
+    <path d="M 218.719432 356.477812 
+L 229.287614 356.477812 
+L 229.287614 314.106428 
+L 218.719432 314.106428 
+z
+" clip-path="url(#p7de345fdc2)" style="fill: #d3d3d3"/>
+   </g>
+   <g id="patch_18">
+    <path d="M 229.287614 356.477812 
+L 239.855795 356.477812 
+L 239.855795 314.106428 
+L 229.287614 314.106428 
+z
+" clip-path="url(#p7de345fdc2)" style="fill: #d3d3d3"/>
+   </g>
+   <g id="patch_19">
+    <path d="M 239.855795 356.477812 
+L 250.423977 356.477812 
+L 250.423977 309.179523 
+L 239.855795 309.179523 
+z
+" clip-path="url(#p7de345fdc2)" style="fill: #d3d3d3"/>
+   </g>
+   <g id="patch_20">
+    <path d="M 250.423977 356.477812 
+L 260.992159 356.477812 
+L 260.992159 309.179523 
+L 250.423977 309.179523 
+z
+" clip-path="url(#p7de345fdc2)" style="fill: #d3d3d3"/>
+   </g>
+   <g id="patch_21">
+    <path d="M 260.992159 356.477812 
+L 271.560341 356.477812 
+L 271.560341 309.179523 
+L 260.992159 309.179523 
+z
+" clip-path="url(#p7de345fdc2)" style="fill: #d3d3d3"/>
+   </g>
+   <g id="patch_22">
+    <path d="M 271.560341 356.477812 
+L 282.128523 356.477812 
+L 282.128523 309.179523 
+L 271.560341 309.179523 
+z
+" clip-path="url(#p7de345fdc2)" style="fill: #d3d3d3"/>
+   </g>
+   <g id="patch_23">
+    <path d="M 282.128523 356.477812 
+L 292.696705 356.477812 
+L 292.696705 304.252618 
+L 282.128523 304.252618 
+z
+" clip-path="url(#p7de345fdc2)" style="fill: #d3d3d3"/>
+   </g>
+   <g id="patch_24">
+    <path d="M 292.696705 356.477812 
+L 303.264886 356.477812 
+L 303.264886 304.252618 
+L 292.696705 304.252618 
+z
+" clip-path="url(#p7de345fdc2)" style="fill: #d3d3d3"/>
+   </g>
+   <g id="patch_25">
+    <path d="M 303.264886 356.477812 
+L 313.833068 356.477812 
+L 313.833068 304.252618 
+L 303.264886 304.252618 
+z
+" clip-path="url(#p7de345fdc2)" style="fill: #d3d3d3"/>
+   </g>
+   <g id="patch_26">
+    <path d="M 313.833068 356.477812 
+L 324.40125 356.477812 
+L 324.40125 304.252618 
+L 313.833068 304.252618 
+z
+" clip-path="url(#p7de345fdc2)" style="fill: #d3d3d3"/>
+   </g>
+   <g id="patch_27">
+    <path d="M 324.40125 356.477812 
+L 334.969432 356.477812 
+L 334.969432 199.802229 
+L 324.40125 199.802229 
+z
+" clip-path="url(#p7de345fdc2)" style="fill: #d3d3d3"/>
+   </g>
+   <g id="patch_28">
+    <path d="M 334.969432 356.477812 
+L 345.537614 356.477812 
+L 345.537614 199.802229 
+L 334.969432 199.802229 
+z
+" clip-path="url(#p7de345fdc2)" style="fill: #d3d3d3"/>
+   </g>
+   <g id="patch_29">
+    <path d="M 345.537614 356.477812 
+L 356.105795 356.477812 
+L 356.105795 199.802229 
+L 345.537614 199.802229 
+z
+" clip-path="url(#p7de345fdc2)" style="fill: #d3d3d3"/>
+   </g>
+   <g id="patch_30">
+    <path d="M 356.105795 356.477812 
+L 366.673977 356.477812 
+L 366.673977 199.802229 
+L 356.105795 199.802229 
+z
+" clip-path="url(#p7de345fdc2)" style="fill: #d3d3d3"/>
+   </g>
+   <g id="patch_31">
+    <path d="M 366.673977 356.477812 
+L 377.242159 356.477812 
+L 377.242159 89.439554 
+L 366.673977 89.439554 
+z
+" clip-path="url(#p7de345fdc2)" style="fill: #d3d3d3"/>
+   </g>
+   <g id="patch_32">
+    <path d="M 377.242159 356.477812 
+L 387.810341 356.477812 
+L 387.810341 89.439554 
+L 377.242159 89.439554 
+z
+" clip-path="url(#p7de345fdc2)" style="fill: #d3d3d3"/>
+   </g>
+   <g id="patch_33">
+    <path d="M 387.810341 356.477812 
+L 398.378523 356.477812 
+L 398.378523 89.439554 
+L 387.810341 89.439554 
+z
+" clip-path="url(#p7de345fdc2)" style="fill: #d3d3d3"/>
+   </g>
+   <g id="patch_34">
+    <path d="M 398.378523 356.477812 
+L 408.946705 356.477812 
+L 408.946705 89.439554 
+L 398.378523 89.439554 
+z
+" clip-path="url(#p7de345fdc2)" style="fill: #d3d3d3"/>
+   </g>
+   <g id="patch_35">
+    <path d="M 408.946705 356.477812 
+L 419.514886 356.477812 
+L 419.514886 318.047952 
+L 408.946705 318.047952 
+z
+" clip-path="url(#p7de345fdc2)" style="fill: #d3d3d3"/>
+   </g>
+   <g id="patch_36">
+    <path d="M 419.514886 356.477812 
+L 430.083068 356.477812 
+L 430.083068 318.047952 
+L 419.514886 318.047952 
+z
+" clip-path="url(#p7de345fdc2)" style="fill: #d3d3d3"/>
+   </g>
+   <g id="patch_37">
+    <path d="M 430.083068 356.477812 
+L 440.65125 356.477812 
+L 440.65125 318.047952 
+L 430.083068 318.047952 
+z
+" clip-path="url(#p7de345fdc2)" style="fill: #d3d3d3"/>
+   </g>
+   <g id="patch_38">
+    <path d="M 440.65125 356.477812 
+L 451.219432 356.477812 
+L 451.219432 318.047952 
+L 440.65125 318.047952 
+z
+" clip-path="url(#p7de345fdc2)" style="fill: #d3d3d3"/>
+   </g>
+   <g id="patch_39">
+    <path d="M 451.219432 356.477812 
+L 461.787614 356.477812 
+L 461.787614 248.0859 
+L 451.219432 248.0859 
+z
+" clip-path="url(#p7de345fdc2)" style="fill: #d3d3d3"/>
+   </g>
+   <g id="patch_40">
+    <path d="M 461.787614 356.477812 
+L 472.355795 356.477812 
+L 472.355795 248.0859 
+L 461.787614 248.0859 
+z
+" clip-path="url(#p7de345fdc2)" style="fill: #d3d3d3"/>
+   </g>
+   <g id="patch_41">
+    <path d="M 472.355795 356.477812 
+L 482.923977 356.477812 
+L 482.923977 248.0859 
+L 472.355795 248.0859 
+z
+" clip-path="url(#p7de345fdc2)" style="fill: #d3d3d3"/>
+   </g>
+   <g id="patch_42">
+    <path d="M 482.923977 356.477812 
+L 493.492159 356.477812 
+L 493.492159 248.0859 
+L 482.923977 248.0859 
+z
+" clip-path="url(#p7de345fdc2)" style="fill: #d3d3d3"/>
+   </g>
+   <g id="patch_43">
+    <path d="M 493.492159 356.477812 
+L 504.060341 356.477812 
+L 504.060341 345.638621 
+L 493.492159 345.638621 
+z
+" clip-path="url(#p7de345fdc2)" style="fill: #d3d3d3"/>
+   </g>
+   <g id="patch_44">
+    <path d="M 504.060341 356.477812 
+L 514.628523 356.477812 
+L 514.628523 345.638621 
+L 504.060341 345.638621 
+z
+" clip-path="url(#p7de345fdc2)" style="fill: #d3d3d3"/>
+   </g>
+   <g id="patch_45">
+    <path d="M 514.628523 356.477812 
+L 525.196705 356.477812 
+L 525.196705 345.638621 
+L 514.628523 345.638621 
+z
+" clip-path="url(#p7de345fdc2)" style="fill: #d3d3d3"/>
+   </g>
+   <g id="patch_46">
+    <path d="M 525.196705 356.477812 
+L 535.764886 356.477812 
+L 535.764886 345.638621 
+L 525.196705 345.638621 
+z
+" clip-path="url(#p7de345fdc2)" style="fill: #d3d3d3"/>
+   </g>
+   <g id="patch_47">
+    <path d="M 535.764886 356.477812 
+L 546.333068 356.477812 
+L 546.333068 356.477812 
+L 535.764886 356.477812 
+z
+" clip-path="url(#p7de345fdc2)" style="fill: #d3d3d3"/>
+   </g>
+   <g id="patch_48">
+    <path d="M 546.333068 356.477812 
+L 556.90125 356.477812 
+L 556.90125 356.477812 
+L 546.333068 356.477812 
+z
+" clip-path="url(#p7de345fdc2)" style="fill: #d3d3d3"/>
+   </g>
+   <g id="patch_49">
+    <path d="M 556.90125 356.477812 
+L 567.469432 356.477812 
+L 567.469432 356.477812 
+L 556.90125 356.477812 
+z
+" clip-path="url(#p7de345fdc2)" style="fill: #d3d3d3"/>
+   </g>
+   <g id="patch_50">
+    <path d="M 567.469432 356.477812 
+L 578.037614 356.477812 
+L 578.037614 356.477812 
+L 567.469432 356.477812 
+z
+" clip-path="url(#p7de345fdc2)" style="fill: #d3d3d3"/>
+   </g>
+   <g id="patch_51">
+    <path d="M 102.469432 356.477812 
+L 165.878523 356.477812 
+L 165.878523 320.75775 
+L 102.469432 320.75775 
+L 102.469432 356.477812 
+z
+" clip-path="url(#p7de345fdc2)" style="fill: none; stroke: #000000; stroke-width: 1.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="matplotlib.axis_1">
+    <g id="xtick_1">
+     <g id="line2d_1">
+      <path d="M 70.764886 356.477812 
+L 70.764886 23.837812 
+" clip-path="url(#p7de345fdc2)" style="fill: none; stroke-dasharray: 2.22,0.96; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.7; stroke-width: 0.6"/>
+     </g>
+     <g id="line2d_2">
+      <defs>
+       <path id="md816adce21" d="M 0 0 
+L 0 -3.5 
+" style="stroke: #1a1a1a; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#md816adce21" x="70.764886" y="356.477812" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_1">
+      <!-- 06:00 -->
+      <g style="fill: #1a1a1a" transform="translate(48.916392 385.728653) rotate(-45) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-30" d="M 2034 4250 
+Q 1547 4250 1301 3770 
+Q 1056 3291 1056 2328 
+Q 1056 1369 1301 889 
+Q 1547 409 2034 409 
+Q 2525 409 2770 889 
+Q 3016 1369 3016 2328 
+Q 3016 3291 2770 3770 
+Q 2525 4250 2034 4250 
+z
+M 2034 4750 
+Q 2819 4750 3233 4129 
+Q 3647 3509 3647 2328 
+Q 3647 1150 3233 529 
+Q 2819 -91 2034 -91 
+Q 1250 -91 836 529 
+Q 422 1150 422 2328 
+Q 422 3509 836 4129 
+Q 1250 4750 2034 4750 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-36" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
+z
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-3a" d="M 750 794 
+L 1409 794 
+L 1409 0 
+L 750 0 
+L 750 794 
+z
+M 750 3309 
+L 1409 3309 
+L 1409 2516 
+L 750 2516 
+L 750 3309 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-36" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-3a" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-30" x="160.9375"/>
+       <use xlink:href="#DejaVuSans-30" x="224.560547"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_2">
+     <g id="line2d_3">
+      <path d="M 113.037614 356.477812 
+L 113.037614 23.837812 
+" clip-path="url(#p7de345fdc2)" style="fill: none; stroke-dasharray: 2.22,0.96; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.7; stroke-width: 0.6"/>
+     </g>
+     <g id="line2d_4">
+      <g>
+       <use xlink:href="#md816adce21" x="113.037614" y="356.477812" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_2">
+      <!-- 07:00 -->
+      <g style="fill: #1a1a1a" transform="translate(91.189119 385.728653) rotate(-45) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-37" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-3a" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-30" x="160.9375"/>
+       <use xlink:href="#DejaVuSans-30" x="224.560547"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_3">
+     <g id="line2d_5">
+      <path d="M 155.310341 356.477812 
+L 155.310341 23.837812 
+" clip-path="url(#p7de345fdc2)" style="fill: none; stroke-dasharray: 2.22,0.96; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.7; stroke-width: 0.6"/>
+     </g>
+     <g id="line2d_6">
+      <g>
+       <use xlink:href="#md816adce21" x="155.310341" y="356.477812" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_3">
+      <!-- 08:00 -->
+      <g style="fill: #1a1a1a" transform="translate(133.461846 385.728653) rotate(-45) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-38" d="M 2034 2216 
+Q 1584 2216 1326 1975 
+Q 1069 1734 1069 1313 
+Q 1069 891 1326 650 
+Q 1584 409 2034 409 
+Q 2484 409 2743 651 
+Q 3003 894 3003 1313 
+Q 3003 1734 2745 1975 
+Q 2488 2216 2034 2216 
+z
+M 1403 2484 
+Q 997 2584 770 2862 
+Q 544 3141 544 3541 
+Q 544 4100 942 4425 
+Q 1341 4750 2034 4750 
+Q 2731 4750 3128 4425 
+Q 3525 4100 3525 3541 
+Q 3525 3141 3298 2862 
+Q 3072 2584 2669 2484 
+Q 3125 2378 3379 2068 
+Q 3634 1759 3634 1313 
+Q 3634 634 3220 271 
+Q 2806 -91 2034 -91 
+Q 1263 -91 848 271 
+Q 434 634 434 1313 
+Q 434 1759 690 2068 
+Q 947 2378 1403 2484 
+z
+M 1172 3481 
+Q 1172 3119 1398 2916 
+Q 1625 2713 2034 2713 
+Q 2441 2713 2670 2916 
+Q 2900 3119 2900 3481 
+Q 2900 3844 2670 4047 
+Q 2441 4250 2034 4250 
+Q 1625 4250 1398 4047 
+Q 1172 3844 1172 3481 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-38" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-3a" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-30" x="160.9375"/>
+       <use xlink:href="#DejaVuSans-30" x="224.560547"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_4">
+     <g id="line2d_7">
+      <path d="M 197.583068 356.477812 
+L 197.583068 23.837812 
+" clip-path="url(#p7de345fdc2)" style="fill: none; stroke-dasharray: 2.22,0.96; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.7; stroke-width: 0.6"/>
+     </g>
+     <g id="line2d_8">
+      <g>
+       <use xlink:href="#md816adce21" x="197.583068" y="356.477812" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_4">
+      <!-- 09:00 -->
+      <g style="fill: #1a1a1a" transform="translate(175.734573 385.728653) rotate(-45) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-39" d="M 703 97 
+L 703 672 
+Q 941 559 1184 500 
+Q 1428 441 1663 441 
+Q 2288 441 2617 861 
+Q 2947 1281 2994 2138 
+Q 2813 1869 2534 1725 
+Q 2256 1581 1919 1581 
+Q 1219 1581 811 2004 
+Q 403 2428 403 3163 
+Q 403 3881 828 4315 
+Q 1253 4750 1959 4750 
+Q 2769 4750 3195 4129 
+Q 3622 3509 3622 2328 
+Q 3622 1225 3098 567 
+Q 2575 -91 1691 -91 
+Q 1453 -91 1209 -44 
+Q 966 3 703 97 
+z
+M 1959 2075 
+Q 2384 2075 2632 2365 
+Q 2881 2656 2881 3163 
+Q 2881 3666 2632 3958 
+Q 2384 4250 1959 4250 
+Q 1534 4250 1286 3958 
+Q 1038 3666 1038 3163 
+Q 1038 2656 1286 2365 
+Q 1534 2075 1959 2075 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-39" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-3a" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-30" x="160.9375"/>
+       <use xlink:href="#DejaVuSans-30" x="224.560547"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_5">
+     <g id="line2d_9">
+      <path d="M 239.855795 356.477812 
+L 239.855795 23.837812 
+" clip-path="url(#p7de345fdc2)" style="fill: none; stroke-dasharray: 2.22,0.96; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.7; stroke-width: 0.6"/>
+     </g>
+     <g id="line2d_10">
+      <g>
+       <use xlink:href="#md816adce21" x="239.855795" y="356.477812" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_5">
+      <!-- 10:00 -->
+      <g style="fill: #1a1a1a" transform="translate(218.007301 385.728653) rotate(-45) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-31" d="M 794 531 
+L 1825 531 
+L 1825 4091 
+L 703 3866 
+L 703 4441 
+L 1819 4666 
+L 2450 4666 
+L 2450 531 
+L 3481 531 
+L 3481 0 
+L 794 0 
+L 794 531 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-3a" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-30" x="160.9375"/>
+       <use xlink:href="#DejaVuSans-30" x="224.560547"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_6">
+     <g id="line2d_11">
+      <path d="M 282.128523 356.477812 
+L 282.128523 23.837812 
+" clip-path="url(#p7de345fdc2)" style="fill: none; stroke-dasharray: 2.22,0.96; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.7; stroke-width: 0.6"/>
+     </g>
+     <g id="line2d_12">
+      <g>
+       <use xlink:href="#md816adce21" x="282.128523" y="356.477812" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_6">
+      <!-- 11:00 -->
+      <g style="fill: #1a1a1a" transform="translate(260.280028 385.728653) rotate(-45) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-3a" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-30" x="160.9375"/>
+       <use xlink:href="#DejaVuSans-30" x="224.560547"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_7">
+     <g id="line2d_13">
+      <path d="M 324.40125 356.477812 
+L 324.40125 23.837812 
+" clip-path="url(#p7de345fdc2)" style="fill: none; stroke-dasharray: 2.22,0.96; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.7; stroke-width: 0.6"/>
+     </g>
+     <g id="line2d_14">
+      <g>
+       <use xlink:href="#md816adce21" x="324.40125" y="356.477812" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_7">
+      <!-- 12:00 -->
+      <g style="fill: #1a1a1a" transform="translate(302.552755 385.728653) rotate(-45) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-32" d="M 1228 531 
+L 3431 531 
+L 3431 0 
+L 469 0 
+L 469 531 
+Q 828 903 1448 1529 
+Q 2069 2156 2228 2338 
+Q 2531 2678 2651 2914 
+Q 2772 3150 2772 3378 
+Q 2772 3750 2511 3984 
+Q 2250 4219 1831 4219 
+Q 1534 4219 1204 4116 
+Q 875 4013 500 3803 
+L 500 4441 
+Q 881 4594 1212 4672 
+Q 1544 4750 1819 4750 
+Q 2544 4750 2975 4387 
+Q 3406 4025 3406 3419 
+Q 3406 3131 3298 2873 
+Q 3191 2616 2906 2266 
+Q 2828 2175 2409 1742 
+Q 1991 1309 1228 531 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-3a" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-30" x="160.9375"/>
+       <use xlink:href="#DejaVuSans-30" x="224.560547"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_8">
+     <g id="line2d_15">
+      <path d="M 366.673977 356.477812 
+L 366.673977 23.837812 
+" clip-path="url(#p7de345fdc2)" style="fill: none; stroke-dasharray: 2.22,0.96; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.7; stroke-width: 0.6"/>
+     </g>
+     <g id="line2d_16">
+      <g>
+       <use xlink:href="#md816adce21" x="366.673977" y="356.477812" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_8">
+      <!-- 13:00 -->
+      <g style="fill: #1a1a1a" transform="translate(344.825483 385.728653) rotate(-45) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-33" d="M 2597 2516 
+Q 3050 2419 3304 2112 
+Q 3559 1806 3559 1356 
+Q 3559 666 3084 287 
+Q 2609 -91 1734 -91 
+Q 1441 -91 1130 -33 
+Q 819 25 488 141 
+L 488 750 
+Q 750 597 1062 519 
+Q 1375 441 1716 441 
+Q 2309 441 2620 675 
+Q 2931 909 2931 1356 
+Q 2931 1769 2642 2001 
+Q 2353 2234 1838 2234 
+L 1294 2234 
+L 1294 2753 
+L 1863 2753 
+Q 2328 2753 2575 2939 
+Q 2822 3125 2822 3475 
+Q 2822 3834 2567 4026 
+Q 2313 4219 1838 4219 
+Q 1578 4219 1281 4162 
+Q 984 4106 628 3988 
+L 628 4550 
+Q 988 4650 1302 4700 
+Q 1616 4750 1894 4750 
+Q 2613 4750 3031 4423 
+Q 3450 4097 3450 3541 
+Q 3450 3153 3228 2886 
+Q 3006 2619 2597 2516 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-33" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-3a" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-30" x="160.9375"/>
+       <use xlink:href="#DejaVuSans-30" x="224.560547"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_9">
+     <g id="line2d_17">
+      <path d="M 408.946705 356.477812 
+L 408.946705 23.837812 
+" clip-path="url(#p7de345fdc2)" style="fill: none; stroke-dasharray: 2.22,0.96; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.7; stroke-width: 0.6"/>
+     </g>
+     <g id="line2d_18">
+      <g>
+       <use xlink:href="#md816adce21" x="408.946705" y="356.477812" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_9">
+      <!-- 14:00 -->
+      <g style="fill: #1a1a1a" transform="translate(387.09821 385.728653) rotate(-45) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-34" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-3a" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-30" x="160.9375"/>
+       <use xlink:href="#DejaVuSans-30" x="224.560547"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_10">
+     <g id="line2d_19">
+      <path d="M 451.219432 356.477812 
+L 451.219432 23.837812 
+" clip-path="url(#p7de345fdc2)" style="fill: none; stroke-dasharray: 2.22,0.96; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.7; stroke-width: 0.6"/>
+     </g>
+     <g id="line2d_20">
+      <g>
+       <use xlink:href="#md816adce21" x="451.219432" y="356.477812" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_10">
+      <!-- 15:00 -->
+      <g style="fill: #1a1a1a" transform="translate(429.370937 385.728653) rotate(-45) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-35" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-3a" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-30" x="160.9375"/>
+       <use xlink:href="#DejaVuSans-30" x="224.560547"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_11">
+     <g id="line2d_21">
+      <path d="M 493.492159 356.477812 
+L 493.492159 23.837812 
+" clip-path="url(#p7de345fdc2)" style="fill: none; stroke-dasharray: 2.22,0.96; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.7; stroke-width: 0.6"/>
+     </g>
+     <g id="line2d_22">
+      <g>
+       <use xlink:href="#md816adce21" x="493.492159" y="356.477812" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_11">
+      <!-- 16:00 -->
+      <g style="fill: #1a1a1a" transform="translate(471.643664 385.728653) rotate(-45) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-36" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-3a" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-30" x="160.9375"/>
+       <use xlink:href="#DejaVuSans-30" x="224.560547"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_12">
+     <g id="line2d_23">
+      <path d="M 535.764886 356.477812 
+L 535.764886 23.837812 
+" clip-path="url(#p7de345fdc2)" style="fill: none; stroke-dasharray: 2.22,0.96; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.7; stroke-width: 0.6"/>
+     </g>
+     <g id="line2d_24">
+      <g>
+       <use xlink:href="#md816adce21" x="535.764886" y="356.477812" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_12">
+      <!-- 17:00 -->
+      <g style="fill: #1a1a1a" transform="translate(513.916392 385.728653) rotate(-45) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-37" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-3a" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-30" x="160.9375"/>
+       <use xlink:href="#DejaVuSans-30" x="224.560547"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_13">
+     <g id="line2d_25">
+      <path d="M 578.037614 356.477812 
+L 578.037614 23.837812 
+" clip-path="url(#p7de345fdc2)" style="fill: none; stroke-dasharray: 2.22,0.96; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.7; stroke-width: 0.6"/>
+     </g>
+     <g id="line2d_26">
+      <g>
+       <use xlink:href="#md816adce21" x="578.037614" y="356.477812" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_13">
+      <!-- 18:00 -->
+      <g style="fill: #1a1a1a" transform="translate(556.189119 385.728653) rotate(-45) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-38" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-3a" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-30" x="160.9375"/>
+       <use xlink:href="#DejaVuSans-30" x="224.560547"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_14">
+     <!-- Time -->
+     <g style="fill: #1a1a1a" transform="translate(309.720937 400.317339) scale(0.12 -0.12)">
+      <defs>
+       <path id="DejaVuSans-54" d="M -19 4666 
+L 3928 4666 
+L 3928 4134 
+L 2272 4134 
+L 2272 0 
+L 1638 0 
+L 1638 4134 
+L -19 4134 
+L -19 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-69" d="M 603 3500 
+L 1178 3500 
+L 1178 0 
+L 603 0 
+L 603 3500 
+z
+M 603 4863 
+L 1178 4863 
+L 1178 4134 
+L 603 4134 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6d" d="M 3328 2828 
+Q 3544 3216 3844 3400 
+Q 4144 3584 4550 3584 
+Q 5097 3584 5394 3201 
+Q 5691 2819 5691 2113 
+L 5691 0 
+L 5113 0 
+L 5113 2094 
+Q 5113 2597 4934 2840 
+Q 4756 3084 4391 3084 
+Q 3944 3084 3684 2787 
+Q 3425 2491 3425 1978 
+L 3425 0 
+L 2847 0 
+L 2847 2094 
+Q 2847 2600 2669 2842 
+Q 2491 3084 2119 3084 
+Q 1678 3084 1418 2786 
+Q 1159 2488 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1356 3278 1631 3431 
+Q 1906 3584 2284 3584 
+Q 2666 3584 2933 3390 
+Q 3200 3197 3328 2828 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-65" d="M 3597 1894 
+L 3597 1613 
+L 953 1613 
+Q 991 1019 1311 708 
+Q 1631 397 2203 397 
+Q 2534 397 2845 478 
+Q 3156 559 3463 722 
+L 3463 178 
+Q 3153 47 2828 -22 
+Q 2503 -91 2169 -91 
+Q 1331 -91 842 396 
+Q 353 884 353 1716 
+Q 353 2575 817 3079 
+Q 1281 3584 2069 3584 
+Q 2775 3584 3186 3129 
+Q 3597 2675 3597 1894 
+z
+M 3022 2063 
+Q 3016 2534 2758 2815 
+Q 2500 3097 2075 3097 
+Q 1594 3097 1305 2825 
+Q 1016 2553 972 2059 
+L 3022 2063 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-54"/>
+      <use xlink:href="#DejaVuSans-69" x="57.958984"/>
+      <use xlink:href="#DejaVuSans-6d" x="85.742188"/>
+      <use xlink:href="#DejaVuSans-65" x="183.154297"/>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_27">
+      <path d="M 45.40125 356.477812 
+L 603.40125 356.477812 
+" clip-path="url(#p7de345fdc2)" style="fill: none; stroke-dasharray: 2.22,0.96; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.7; stroke-width: 0.6"/>
+     </g>
+     <g id="line2d_28">
+      <defs>
+       <path id="m5f231f2fb5" d="M 0 0 
+L 3.5 0 
+" style="stroke: #1a1a1a; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m5f231f2fb5" x="45.40125" y="356.477812" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_15">
+      <!-- 0 -->
+      <g style="fill: #1a1a1a" transform="translate(35.53875 360.277031) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_29">
+      <path d="M 45.40125 301.734422 
+L 603.40125 301.734422 
+" clip-path="url(#p7de345fdc2)" style="fill: none; stroke-dasharray: 2.22,0.96; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.7; stroke-width: 0.6"/>
+     </g>
+     <g id="line2d_30">
+      <g>
+       <use xlink:href="#m5f231f2fb5" x="45.40125" y="301.734422" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_16">
+      <!-- 50 -->
+      <g style="fill: #1a1a1a" transform="translate(29.17625 305.533641) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-35"/>
+       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_3">
+     <g id="line2d_31">
+      <path d="M 45.40125 246.991032 
+L 603.40125 246.991032 
+" clip-path="url(#p7de345fdc2)" style="fill: none; stroke-dasharray: 2.22,0.96; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.7; stroke-width: 0.6"/>
+     </g>
+     <g id="line2d_32">
+      <g>
+       <use xlink:href="#m5f231f2fb5" x="45.40125" y="246.991032" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_17">
+      <!-- 100 -->
+      <g style="fill: #1a1a1a" transform="translate(22.81375 250.790251) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_4">
+     <g id="line2d_33">
+      <path d="M 45.40125 192.247641 
+L 603.40125 192.247641 
+" clip-path="url(#p7de345fdc2)" style="fill: none; stroke-dasharray: 2.22,0.96; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.7; stroke-width: 0.6"/>
+     </g>
+     <g id="line2d_34">
+      <g>
+       <use xlink:href="#m5f231f2fb5" x="45.40125" y="192.247641" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_18">
+      <!-- 150 -->
+      <g style="fill: #1a1a1a" transform="translate(22.81375 196.04686) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-35" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_5">
+     <g id="line2d_35">
+      <path d="M 45.40125 137.504251 
+L 603.40125 137.504251 
+" clip-path="url(#p7de345fdc2)" style="fill: none; stroke-dasharray: 2.22,0.96; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.7; stroke-width: 0.6"/>
+     </g>
+     <g id="line2d_36">
+      <g>
+       <use xlink:href="#m5f231f2fb5" x="45.40125" y="137.504251" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_19">
+      <!-- 200 -->
+      <g style="fill: #1a1a1a" transform="translate(22.81375 141.30347) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-32"/>
+       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_6">
+     <g id="line2d_37">
+      <path d="M 45.40125 82.760861 
+L 603.40125 82.760861 
+" clip-path="url(#p7de345fdc2)" style="fill: none; stroke-dasharray: 2.22,0.96; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.7; stroke-width: 0.6"/>
+     </g>
+     <g id="line2d_38">
+      <g>
+       <use xlink:href="#m5f231f2fb5" x="45.40125" y="82.760861" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_20">
+      <!-- 250 -->
+      <g style="fill: #1a1a1a" transform="translate(22.81375 86.560079) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-32"/>
+       <use xlink:href="#DejaVuSans-35" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_7">
+     <g id="line2d_39">
+      <path d="M 45.40125 28.01747 
+L 603.40125 28.01747 
+" clip-path="url(#p7de345fdc2)" style="fill: none; stroke-dasharray: 2.22,0.96; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.7; stroke-width: 0.6"/>
+     </g>
+     <g id="line2d_40">
+      <g>
+       <use xlink:href="#m5f231f2fb5" x="45.40125" y="28.01747" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_21">
+      <!-- 300 -->
+      <g style="fill: #1a1a1a" transform="translate(22.81375 31.816689) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-33"/>
+       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_22">
+     <!-- Solar radiation [W/m^2] -->
+     <g style="fill: #1a1a1a" transform="translate(16.318125 263.376562) rotate(-90) scale(0.12 -0.12)">
+      <defs>
+       <path id="DejaVuSans-53" d="M 3425 4513 
+L 3425 3897 
+Q 3066 4069 2747 4153 
+Q 2428 4238 2131 4238 
+Q 1616 4238 1336 4038 
+Q 1056 3838 1056 3469 
+Q 1056 3159 1242 3001 
+Q 1428 2844 1947 2747 
+L 2328 2669 
+Q 3034 2534 3370 2195 
+Q 3706 1856 3706 1288 
+Q 3706 609 3251 259 
+Q 2797 -91 1919 -91 
+Q 1588 -91 1214 -16 
+Q 841 59 441 206 
+L 441 856 
+Q 825 641 1194 531 
+Q 1563 422 1919 422 
+Q 2459 422 2753 634 
+Q 3047 847 3047 1241 
+Q 3047 1584 2836 1778 
+Q 2625 1972 2144 2069 
+L 1759 2144 
+Q 1053 2284 737 2584 
+Q 422 2884 422 3419 
+Q 422 4038 858 4394 
+Q 1294 4750 2059 4750 
+Q 2388 4750 2728 4690 
+Q 3069 4631 3425 4513 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6f" d="M 1959 3097 
+Q 1497 3097 1228 2736 
+Q 959 2375 959 1747 
+Q 959 1119 1226 758 
+Q 1494 397 1959 397 
+Q 2419 397 2687 759 
+Q 2956 1122 2956 1747 
+Q 2956 2369 2687 2733 
+Q 2419 3097 1959 3097 
+z
+M 1959 3584 
+Q 2709 3584 3137 3096 
+Q 3566 2609 3566 1747 
+Q 3566 888 3137 398 
+Q 2709 -91 1959 -91 
+Q 1206 -91 779 398 
+Q 353 888 353 1747 
+Q 353 2609 779 3096 
+Q 1206 3584 1959 3584 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6c" d="M 603 4863 
+L 1178 4863 
+L 1178 0 
+L 603 0 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-61" d="M 2194 1759 
+Q 1497 1759 1228 1600 
+Q 959 1441 959 1056 
+Q 959 750 1161 570 
+Q 1363 391 1709 391 
+Q 2188 391 2477 730 
+Q 2766 1069 2766 1631 
+L 2766 1759 
+L 2194 1759 
+z
+M 3341 1997 
+L 3341 0 
+L 2766 0 
+L 2766 531 
+Q 2569 213 2275 61 
+Q 1981 -91 1556 -91 
+Q 1019 -91 701 211 
+Q 384 513 384 1019 
+Q 384 1609 779 1909 
+Q 1175 2209 1959 2209 
+L 2766 2209 
+L 2766 2266 
+Q 2766 2663 2505 2880 
+Q 2244 3097 1772 3097 
+Q 1472 3097 1187 3025 
+Q 903 2953 641 2809 
+L 641 3341 
+Q 956 3463 1253 3523 
+Q 1550 3584 1831 3584 
+Q 2591 3584 2966 3190 
+Q 3341 2797 3341 1997 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-72" d="M 2631 2963 
+Q 2534 3019 2420 3045 
+Q 2306 3072 2169 3072 
+Q 1681 3072 1420 2755 
+Q 1159 2438 1159 1844 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1341 3275 1631 3429 
+Q 1922 3584 2338 3584 
+Q 2397 3584 2469 3576 
+Q 2541 3569 2628 3553 
+L 2631 2963 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-20" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-64" d="M 2906 2969 
+L 2906 4863 
+L 3481 4863 
+L 3481 0 
+L 2906 0 
+L 2906 525 
+Q 2725 213 2448 61 
+Q 2172 -91 1784 -91 
+Q 1150 -91 751 415 
+Q 353 922 353 1747 
+Q 353 2572 751 3078 
+Q 1150 3584 1784 3584 
+Q 2172 3584 2448 3432 
+Q 2725 3281 2906 2969 
+z
+M 947 1747 
+Q 947 1113 1208 752 
+Q 1469 391 1925 391 
+Q 2381 391 2643 752 
+Q 2906 1113 2906 1747 
+Q 2906 2381 2643 2742 
+Q 2381 3103 1925 3103 
+Q 1469 3103 1208 2742 
+Q 947 2381 947 1747 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-74" d="M 1172 4494 
+L 1172 3500 
+L 2356 3500 
+L 2356 3053 
+L 1172 3053 
+L 1172 1153 
+Q 1172 725 1289 603 
+Q 1406 481 1766 481 
+L 2356 481 
+L 2356 0 
+L 1766 0 
+Q 1100 0 847 248 
+Q 594 497 594 1153 
+L 594 3053 
+L 172 3053 
+L 172 3500 
+L 594 3500 
+L 594 4494 
+L 1172 4494 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6e" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-5b" d="M 550 4863 
+L 1875 4863 
+L 1875 4416 
+L 1125 4416 
+L 1125 -397 
+L 1875 -397 
+L 1875 -844 
+L 550 -844 
+L 550 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-57" d="M 213 4666 
+L 850 4666 
+L 1831 722 
+L 2809 4666 
+L 3519 4666 
+L 4500 722 
+L 5478 4666 
+L 6119 4666 
+L 4947 0 
+L 4153 0 
+L 3169 4050 
+L 2175 0 
+L 1381 0 
+L 213 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-2f" d="M 1625 4666 
+L 2156 4666 
+L 531 -594 
+L 0 -594 
+L 1625 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-5e" d="M 2988 4666 
+L 4684 2925 
+L 4056 2925 
+L 2681 4159 
+L 1306 2925 
+L 678 2925 
+L 2375 4666 
+L 2988 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-5d" d="M 1947 4863 
+L 1947 -844 
+L 622 -844 
+L 622 -397 
+L 1369 -397 
+L 1369 4416 
+L 622 4416 
+L 622 4863 
+L 1947 4863 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-53"/>
+      <use xlink:href="#DejaVuSans-6f" x="63.476562"/>
+      <use xlink:href="#DejaVuSans-6c" x="124.658203"/>
+      <use xlink:href="#DejaVuSans-61" x="152.441406"/>
+      <use xlink:href="#DejaVuSans-72" x="213.720703"/>
+      <use xlink:href="#DejaVuSans-20" x="254.833984"/>
+      <use xlink:href="#DejaVuSans-72" x="286.621094"/>
+      <use xlink:href="#DejaVuSans-61" x="327.734375"/>
+      <use xlink:href="#DejaVuSans-64" x="389.013672"/>
+      <use xlink:href="#DejaVuSans-69" x="452.490234"/>
+      <use xlink:href="#DejaVuSans-61" x="480.273438"/>
+      <use xlink:href="#DejaVuSans-74" x="541.552734"/>
+      <use xlink:href="#DejaVuSans-69" x="580.761719"/>
+      <use xlink:href="#DejaVuSans-6f" x="608.544922"/>
+      <use xlink:href="#DejaVuSans-6e" x="669.726562"/>
+      <use xlink:href="#DejaVuSans-20" x="733.105469"/>
+      <use xlink:href="#DejaVuSans-5b" x="764.892578"/>
+      <use xlink:href="#DejaVuSans-57" x="803.90625"/>
+      <use xlink:href="#DejaVuSans-2f" x="902.783203"/>
+      <use xlink:href="#DejaVuSans-6d" x="936.474609"/>
+      <use xlink:href="#DejaVuSans-5e" x="1033.886719"/>
+      <use xlink:href="#DejaVuSans-32" x="1117.675781"/>
+      <use xlink:href="#DejaVuSans-5d" x="1181.298828"/>
+     </g>
+    </g>
+   </g>
+   <g id="line2d_41">
+    <path d="M 70.764886 356.477812 
+L 81.333068 356.477812 
+L 91.90125 356.477812 
+L 102.469432 356.477812 
+L 113.037614 353.521669 
+L 123.605795 353.521669 
+L 134.173977 353.521669 
+L 144.742159 353.521669 
+L 155.310341 322.974858 
+L 165.878523 322.974858 
+L 176.446705 322.974858 
+L 187.014886 322.974858 
+L 197.583068 314.106428 
+L 208.15125 314.106428 
+L 218.719432 314.106428 
+L 229.287614 314.106428 
+L 239.855795 309.179523 
+L 250.423977 309.179523 
+L 260.992159 309.179523 
+L 271.560341 309.179523 
+L 282.128523 304.252618 
+L 292.696705 304.252618 
+L 303.264886 304.252618 
+L 313.833068 304.252618 
+L 324.40125 199.802229 
+L 334.969432 199.802229 
+L 345.537614 199.802229 
+L 356.105795 199.802229 
+L 366.673977 89.439554 
+L 377.242159 89.439554 
+L 387.810341 89.439554 
+L 398.378523 89.439554 
+L 408.946705 318.047952 
+L 419.514886 318.047952 
+L 430.083068 318.047952 
+L 440.65125 318.047952 
+L 451.219432 248.0859 
+L 461.787614 248.0859 
+L 472.355795 248.0859 
+L 482.923977 248.0859 
+L 493.492159 345.638621 
+L 504.060341 345.638621 
+L 514.628523 345.638621 
+L 525.196705 345.638621 
+L 535.764886 356.477812 
+L 546.333068 356.477812 
+L 556.90125 356.477812 
+L 567.469432 356.477812 
+" clip-path="url(#p7de345fdc2)" style="fill: none; stroke: #ddaa33; stroke-width: 2; stroke-linecap: square"/>
+    <defs>
+     <path id="me276cf5891" d="M 0 3 
+C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
+C 2.683901 1.55874 3 0.795609 3 0 
+C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
+C 1.55874 -2.683901 0.795609 -3 0 -3 
+C -0.795609 -3 -1.55874 -2.683901 -2.12132 -2.12132 
+C -2.683901 -1.55874 -3 -0.795609 -3 0 
+C -3 0.795609 -2.683901 1.55874 -2.12132 2.12132 
+C -1.55874 2.683901 -0.795609 3 0 3 
+z
+"/>
+    </defs>
+    <g clip-path="url(#p7de345fdc2)">
+     <use xlink:href="#me276cf5891" x="70.764886" y="356.477812" style="fill: #ddaa33"/>
+     <use xlink:href="#me276cf5891" x="81.333068" y="356.477812" style="fill: #ddaa33"/>
+     <use xlink:href="#me276cf5891" x="91.90125" y="356.477812" style="fill: #ddaa33"/>
+     <use xlink:href="#me276cf5891" x="102.469432" y="356.477812" style="fill: #ddaa33"/>
+     <use xlink:href="#me276cf5891" x="113.037614" y="353.521669" style="fill: #ddaa33"/>
+     <use xlink:href="#me276cf5891" x="123.605795" y="353.521669" style="fill: #ddaa33"/>
+     <use xlink:href="#me276cf5891" x="134.173977" y="353.521669" style="fill: #ddaa33"/>
+     <use xlink:href="#me276cf5891" x="144.742159" y="353.521669" style="fill: #ddaa33"/>
+     <use xlink:href="#me276cf5891" x="155.310341" y="322.974858" style="fill: #ddaa33"/>
+     <use xlink:href="#me276cf5891" x="165.878523" y="322.974858" style="fill: #ddaa33"/>
+     <use xlink:href="#me276cf5891" x="176.446705" y="322.974858" style="fill: #ddaa33"/>
+     <use xlink:href="#me276cf5891" x="187.014886" y="322.974858" style="fill: #ddaa33"/>
+     <use xlink:href="#me276cf5891" x="197.583068" y="314.106428" style="fill: #ddaa33"/>
+     <use xlink:href="#me276cf5891" x="208.15125" y="314.106428" style="fill: #ddaa33"/>
+     <use xlink:href="#me276cf5891" x="218.719432" y="314.106428" style="fill: #ddaa33"/>
+     <use xlink:href="#me276cf5891" x="229.287614" y="314.106428" style="fill: #ddaa33"/>
+     <use xlink:href="#me276cf5891" x="239.855795" y="309.179523" style="fill: #ddaa33"/>
+     <use xlink:href="#me276cf5891" x="250.423977" y="309.179523" style="fill: #ddaa33"/>
+     <use xlink:href="#me276cf5891" x="260.992159" y="309.179523" style="fill: #ddaa33"/>
+     <use xlink:href="#me276cf5891" x="271.560341" y="309.179523" style="fill: #ddaa33"/>
+     <use xlink:href="#me276cf5891" x="282.128523" y="304.252618" style="fill: #ddaa33"/>
+     <use xlink:href="#me276cf5891" x="292.696705" y="304.252618" style="fill: #ddaa33"/>
+     <use xlink:href="#me276cf5891" x="303.264886" y="304.252618" style="fill: #ddaa33"/>
+     <use xlink:href="#me276cf5891" x="313.833068" y="304.252618" style="fill: #ddaa33"/>
+     <use xlink:href="#me276cf5891" x="324.40125" y="199.802229" style="fill: #ddaa33"/>
+     <use xlink:href="#me276cf5891" x="334.969432" y="199.802229" style="fill: #ddaa33"/>
+     <use xlink:href="#me276cf5891" x="345.537614" y="199.802229" style="fill: #ddaa33"/>
+     <use xlink:href="#me276cf5891" x="356.105795" y="199.802229" style="fill: #ddaa33"/>
+     <use xlink:href="#me276cf5891" x="366.673977" y="89.439554" style="fill: #ddaa33"/>
+     <use xlink:href="#me276cf5891" x="377.242159" y="89.439554" style="fill: #ddaa33"/>
+     <use xlink:href="#me276cf5891" x="387.810341" y="89.439554" style="fill: #ddaa33"/>
+     <use xlink:href="#me276cf5891" x="398.378523" y="89.439554" style="fill: #ddaa33"/>
+     <use xlink:href="#me276cf5891" x="408.946705" y="318.047952" style="fill: #ddaa33"/>
+     <use xlink:href="#me276cf5891" x="419.514886" y="318.047952" style="fill: #ddaa33"/>
+     <use xlink:href="#me276cf5891" x="430.083068" y="318.047952" style="fill: #ddaa33"/>
+     <use xlink:href="#me276cf5891" x="440.65125" y="318.047952" style="fill: #ddaa33"/>
+     <use xlink:href="#me276cf5891" x="451.219432" y="248.0859" style="fill: #ddaa33"/>
+     <use xlink:href="#me276cf5891" x="461.787614" y="248.0859" style="fill: #ddaa33"/>
+     <use xlink:href="#me276cf5891" x="472.355795" y="248.0859" style="fill: #ddaa33"/>
+     <use xlink:href="#me276cf5891" x="482.923977" y="248.0859" style="fill: #ddaa33"/>
+     <use xlink:href="#me276cf5891" x="493.492159" y="345.638621" style="fill: #ddaa33"/>
+     <use xlink:href="#me276cf5891" x="504.060341" y="345.638621" style="fill: #ddaa33"/>
+     <use xlink:href="#me276cf5891" x="514.628523" y="345.638621" style="fill: #ddaa33"/>
+     <use xlink:href="#me276cf5891" x="525.196705" y="345.638621" style="fill: #ddaa33"/>
+     <use xlink:href="#me276cf5891" x="535.764886" y="356.477812" style="fill: #ddaa33"/>
+     <use xlink:href="#me276cf5891" x="546.333068" y="356.477812" style="fill: #ddaa33"/>
+     <use xlink:href="#me276cf5891" x="556.90125" y="356.477812" style="fill: #ddaa33"/>
+     <use xlink:href="#me276cf5891" x="567.469432" y="356.477812" style="fill: #ddaa33"/>
+    </g>
+   </g>
+   <g id="line2d_42">
+    <path d="M 70.764886 356.477812 
+L 81.333068 355.738777 
+L 91.90125 354.999741 
+L 102.469432 354.260705 
+L 113.037614 353.521669 
+L 123.605795 345.884966 
+L 134.173977 338.248264 
+L 144.742159 330.611561 
+L 155.310341 322.974858 
+L 165.878523 320.75775 
+L 176.446705 318.540643 
+L 187.014886 316.323536 
+L 197.583068 314.106428 
+L 208.15125 312.874702 
+L 218.719432 311.642976 
+L 229.287614 310.41125 
+L 239.855795 309.179523 
+L 250.423977 307.947797 
+L 260.992159 306.716071 
+L 271.560341 305.484344 
+L 282.128523 304.252618 
+L 292.696705 278.140021 
+L 303.264886 252.027424 
+L 313.833068 225.914826 
+L 324.40125 199.802229 
+L 334.969432 172.211561 
+L 345.537614 144.620892 
+L 356.105795 117.030223 
+L 366.673977 89.439554 
+L 377.242159 146.591654 
+L 387.810341 203.743753 
+L 398.378523 260.895853 
+L 408.946705 318.047952 
+L 419.514886 300.557439 
+L 430.083068 283.066926 
+L 440.65125 265.576413 
+L 451.219432 248.0859 
+L 461.787614 272.47408 
+L 472.355795 296.86226 
+L 482.923977 321.250441 
+L 493.492159 345.638621 
+L 504.060341 348.348419 
+L 514.628523 351.058217 
+L 525.196705 353.768015 
+L 535.764886 356.477812 
+L 546.333068 356.477812 
+L 556.90125 356.477812 
+L 567.469432 356.477812 
+" clip-path="url(#p7de345fdc2)" style="fill: none; stroke: #004488; stroke-width: 2; stroke-linecap: square"/>
+    <defs>
+     <path id="m11172a4b8e" d="M 0 3 
+C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
+C 2.683901 1.55874 3 0.795609 3 0 
+C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
+C 1.55874 -2.683901 0.795609 -3 0 -3 
+C -0.795609 -3 -1.55874 -2.683901 -2.12132 -2.12132 
+C -2.683901 -1.55874 -3 -0.795609 -3 0 
+C -3 0.795609 -2.683901 1.55874 -2.12132 2.12132 
+C -1.55874 2.683901 -0.795609 3 0 3 
+z
+"/>
+    </defs>
+    <g clip-path="url(#p7de345fdc2)">
+     <use xlink:href="#m11172a4b8e" x="70.764886" y="356.477812" style="fill: #004488"/>
+     <use xlink:href="#m11172a4b8e" x="81.333068" y="355.738777" style="fill: #004488"/>
+     <use xlink:href="#m11172a4b8e" x="91.90125" y="354.999741" style="fill: #004488"/>
+     <use xlink:href="#m11172a4b8e" x="102.469432" y="354.260705" style="fill: #004488"/>
+     <use xlink:href="#m11172a4b8e" x="113.037614" y="353.521669" style="fill: #004488"/>
+     <use xlink:href="#m11172a4b8e" x="123.605795" y="345.884966" style="fill: #004488"/>
+     <use xlink:href="#m11172a4b8e" x="134.173977" y="338.248264" style="fill: #004488"/>
+     <use xlink:href="#m11172a4b8e" x="144.742159" y="330.611561" style="fill: #004488"/>
+     <use xlink:href="#m11172a4b8e" x="155.310341" y="322.974858" style="fill: #004488"/>
+     <use xlink:href="#m11172a4b8e" x="165.878523" y="320.75775" style="fill: #004488"/>
+     <use xlink:href="#m11172a4b8e" x="176.446705" y="318.540643" style="fill: #004488"/>
+     <use xlink:href="#m11172a4b8e" x="187.014886" y="316.323536" style="fill: #004488"/>
+     <use xlink:href="#m11172a4b8e" x="197.583068" y="314.106428" style="fill: #004488"/>
+     <use xlink:href="#m11172a4b8e" x="208.15125" y="312.874702" style="fill: #004488"/>
+     <use xlink:href="#m11172a4b8e" x="218.719432" y="311.642976" style="fill: #004488"/>
+     <use xlink:href="#m11172a4b8e" x="229.287614" y="310.41125" style="fill: #004488"/>
+     <use xlink:href="#m11172a4b8e" x="239.855795" y="309.179523" style="fill: #004488"/>
+     <use xlink:href="#m11172a4b8e" x="250.423977" y="307.947797" style="fill: #004488"/>
+     <use xlink:href="#m11172a4b8e" x="260.992159" y="306.716071" style="fill: #004488"/>
+     <use xlink:href="#m11172a4b8e" x="271.560341" y="305.484344" style="fill: #004488"/>
+     <use xlink:href="#m11172a4b8e" x="282.128523" y="304.252618" style="fill: #004488"/>
+     <use xlink:href="#m11172a4b8e" x="292.696705" y="278.140021" style="fill: #004488"/>
+     <use xlink:href="#m11172a4b8e" x="303.264886" y="252.027424" style="fill: #004488"/>
+     <use xlink:href="#m11172a4b8e" x="313.833068" y="225.914826" style="fill: #004488"/>
+     <use xlink:href="#m11172a4b8e" x="324.40125" y="199.802229" style="fill: #004488"/>
+     <use xlink:href="#m11172a4b8e" x="334.969432" y="172.211561" style="fill: #004488"/>
+     <use xlink:href="#m11172a4b8e" x="345.537614" y="144.620892" style="fill: #004488"/>
+     <use xlink:href="#m11172a4b8e" x="356.105795" y="117.030223" style="fill: #004488"/>
+     <use xlink:href="#m11172a4b8e" x="366.673977" y="89.439554" style="fill: #004488"/>
+     <use xlink:href="#m11172a4b8e" x="377.242159" y="146.591654" style="fill: #004488"/>
+     <use xlink:href="#m11172a4b8e" x="387.810341" y="203.743753" style="fill: #004488"/>
+     <use xlink:href="#m11172a4b8e" x="398.378523" y="260.895853" style="fill: #004488"/>
+     <use xlink:href="#m11172a4b8e" x="408.946705" y="318.047952" style="fill: #004488"/>
+     <use xlink:href="#m11172a4b8e" x="419.514886" y="300.557439" style="fill: #004488"/>
+     <use xlink:href="#m11172a4b8e" x="430.083068" y="283.066926" style="fill: #004488"/>
+     <use xlink:href="#m11172a4b8e" x="440.65125" y="265.576413" style="fill: #004488"/>
+     <use xlink:href="#m11172a4b8e" x="451.219432" y="248.0859" style="fill: #004488"/>
+     <use xlink:href="#m11172a4b8e" x="461.787614" y="272.47408" style="fill: #004488"/>
+     <use xlink:href="#m11172a4b8e" x="472.355795" y="296.86226" style="fill: #004488"/>
+     <use xlink:href="#m11172a4b8e" x="482.923977" y="321.250441" style="fill: #004488"/>
+     <use xlink:href="#m11172a4b8e" x="493.492159" y="345.638621" style="fill: #004488"/>
+     <use xlink:href="#m11172a4b8e" x="504.060341" y="348.348419" style="fill: #004488"/>
+     <use xlink:href="#m11172a4b8e" x="514.628523" y="351.058217" style="fill: #004488"/>
+     <use xlink:href="#m11172a4b8e" x="525.196705" y="353.768015" style="fill: #004488"/>
+     <use xlink:href="#m11172a4b8e" x="535.764886" y="356.477812" style="fill: #004488"/>
+     <use xlink:href="#m11172a4b8e" x="546.333068" y="356.477812" style="fill: #004488"/>
+     <use xlink:href="#m11172a4b8e" x="556.90125" y="356.477812" style="fill: #004488"/>
+     <use xlink:href="#m11172a4b8e" x="567.469432" y="356.477812" style="fill: #004488"/>
+    </g>
+   </g>
+   <g id="line2d_43">
+    <path d="M 70.764886 356.477812 
+L 81.333068 356.477812 
+L 91.90125 356.108295 
+L 102.469432 355.369259 
+L 113.037614 354.630223 
+L 123.605795 353.891187 
+L 134.173977 349.703318 
+L 144.742159 342.066615 
+L 155.310341 334.429912 
+L 165.878523 326.793209 
+L 176.446705 321.866304 
+L 187.014886 319.649197 
+L 197.583068 317.432089 
+L 208.15125 315.214982 
+L 218.719432 313.490565 
+L 229.287614 312.258839 
+L 239.855795 311.027113 
+L 250.423977 309.795386 
+L 260.992159 308.56366 
+L 271.560341 307.331934 
+L 282.128523 306.100208 
+L 292.696705 304.868481 
+L 303.264886 291.196319 
+L 313.833068 265.083722 
+L 324.40125 238.971125 
+L 334.969432 212.858528 
+L 345.537614 186.006895 
+L 356.105795 158.416226 
+L 366.673977 130.825557 
+L 377.242159 103.234889 
+L 387.810341 118.015604 
+L 398.378523 175.167704 
+L 408.946705 232.319803 
+L 419.514886 289.471903 
+L 430.083068 309.302696 
+L 440.65125 291.812183 
+L 451.219432 274.321669 
+L 461.787614 256.831156 
+L 472.355795 260.27999 
+L 482.923977 284.66817 
+L 493.492159 309.056351 
+L 504.060341 333.444531 
+L 514.628523 346.99352 
+L 525.196705 349.703318 
+L 535.764886 352.413116 
+L 546.333068 355.122914 
+L 556.90125 356.477812 
+L 567.469432 356.477812 
+" clip-path="url(#p7de345fdc2)" style="fill: none; stroke: #bb5566; stroke-width: 2; stroke-linecap: square"/>
+    <defs>
+     <path id="me1632f8408" d="M 0 3 
+C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
+C 2.683901 1.55874 3 0.795609 3 0 
+C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
+C 1.55874 -2.683901 0.795609 -3 0 -3 
+C -0.795609 -3 -1.55874 -2.683901 -2.12132 -2.12132 
+C -2.683901 -1.55874 -3 -0.795609 -3 0 
+C -3 0.795609 -2.683901 1.55874 -2.12132 2.12132 
+C -1.55874 2.683901 -0.795609 3 0 3 
+z
+"/>
+    </defs>
+    <g clip-path="url(#p7de345fdc2)">
+     <use xlink:href="#me1632f8408" x="70.764886" y="356.477812" style="fill: #bb5566"/>
+     <use xlink:href="#me1632f8408" x="81.333068" y="356.477812" style="fill: #bb5566"/>
+     <use xlink:href="#me1632f8408" x="91.90125" y="356.108295" style="fill: #bb5566"/>
+     <use xlink:href="#me1632f8408" x="102.469432" y="355.369259" style="fill: #bb5566"/>
+     <use xlink:href="#me1632f8408" x="113.037614" y="354.630223" style="fill: #bb5566"/>
+     <use xlink:href="#me1632f8408" x="123.605795" y="353.891187" style="fill: #bb5566"/>
+     <use xlink:href="#me1632f8408" x="134.173977" y="349.703318" style="fill: #bb5566"/>
+     <use xlink:href="#me1632f8408" x="144.742159" y="342.066615" style="fill: #bb5566"/>
+     <use xlink:href="#me1632f8408" x="155.310341" y="334.429912" style="fill: #bb5566"/>
+     <use xlink:href="#me1632f8408" x="165.878523" y="326.793209" style="fill: #bb5566"/>
+     <use xlink:href="#me1632f8408" x="176.446705" y="321.866304" style="fill: #bb5566"/>
+     <use xlink:href="#me1632f8408" x="187.014886" y="319.649197" style="fill: #bb5566"/>
+     <use xlink:href="#me1632f8408" x="197.583068" y="317.432089" style="fill: #bb5566"/>
+     <use xlink:href="#me1632f8408" x="208.15125" y="315.214982" style="fill: #bb5566"/>
+     <use xlink:href="#me1632f8408" x="218.719432" y="313.490565" style="fill: #bb5566"/>
+     <use xlink:href="#me1632f8408" x="229.287614" y="312.258839" style="fill: #bb5566"/>
+     <use xlink:href="#me1632f8408" x="239.855795" y="311.027113" style="fill: #bb5566"/>
+     <use xlink:href="#me1632f8408" x="250.423977" y="309.795386" style="fill: #bb5566"/>
+     <use xlink:href="#me1632f8408" x="260.992159" y="308.56366" style="fill: #bb5566"/>
+     <use xlink:href="#me1632f8408" x="271.560341" y="307.331934" style="fill: #bb5566"/>
+     <use xlink:href="#me1632f8408" x="282.128523" y="306.100208" style="fill: #bb5566"/>
+     <use xlink:href="#me1632f8408" x="292.696705" y="304.868481" style="fill: #bb5566"/>
+     <use xlink:href="#me1632f8408" x="303.264886" y="291.196319" style="fill: #bb5566"/>
+     <use xlink:href="#me1632f8408" x="313.833068" y="265.083722" style="fill: #bb5566"/>
+     <use xlink:href="#me1632f8408" x="324.40125" y="238.971125" style="fill: #bb5566"/>
+     <use xlink:href="#me1632f8408" x="334.969432" y="212.858528" style="fill: #bb5566"/>
+     <use xlink:href="#me1632f8408" x="345.537614" y="186.006895" style="fill: #bb5566"/>
+     <use xlink:href="#me1632f8408" x="356.105795" y="158.416226" style="fill: #bb5566"/>
+     <use xlink:href="#me1632f8408" x="366.673977" y="130.825557" style="fill: #bb5566"/>
+     <use xlink:href="#me1632f8408" x="377.242159" y="103.234889" style="fill: #bb5566"/>
+     <use xlink:href="#me1632f8408" x="387.810341" y="118.015604" style="fill: #bb5566"/>
+     <use xlink:href="#me1632f8408" x="398.378523" y="175.167704" style="fill: #bb5566"/>
+     <use xlink:href="#me1632f8408" x="408.946705" y="232.319803" style="fill: #bb5566"/>
+     <use xlink:href="#me1632f8408" x="419.514886" y="289.471903" style="fill: #bb5566"/>
+     <use xlink:href="#me1632f8408" x="430.083068" y="309.302696" style="fill: #bb5566"/>
+     <use xlink:href="#me1632f8408" x="440.65125" y="291.812183" style="fill: #bb5566"/>
+     <use xlink:href="#me1632f8408" x="451.219432" y="274.321669" style="fill: #bb5566"/>
+     <use xlink:href="#me1632f8408" x="461.787614" y="256.831156" style="fill: #bb5566"/>
+     <use xlink:href="#me1632f8408" x="472.355795" y="260.27999" style="fill: #bb5566"/>
+     <use xlink:href="#me1632f8408" x="482.923977" y="284.66817" style="fill: #bb5566"/>
+     <use xlink:href="#me1632f8408" x="493.492159" y="309.056351" style="fill: #bb5566"/>
+     <use xlink:href="#me1632f8408" x="504.060341" y="333.444531" style="fill: #bb5566"/>
+     <use xlink:href="#me1632f8408" x="514.628523" y="346.99352" style="fill: #bb5566"/>
+     <use xlink:href="#me1632f8408" x="525.196705" y="349.703318" style="fill: #bb5566"/>
+     <use xlink:href="#me1632f8408" x="535.764886" y="352.413116" style="fill: #bb5566"/>
+     <use xlink:href="#me1632f8408" x="546.333068" y="355.122914" style="fill: #bb5566"/>
+     <use xlink:href="#me1632f8408" x="556.90125" y="356.477812" style="fill: #bb5566"/>
+     <use xlink:href="#me1632f8408" x="567.469432" y="356.477812" style="fill: #bb5566"/>
+    </g>
+   </g>
+   <g id="line2d_44">
+    <path d="M 70.764886 356.477812 
+L 81.333068 356.477812 
+L 91.90125 356.477812 
+L 102.469432 356.477812 
+L 113.037614 356.477812 
+L 123.605795 356.477812 
+L 134.173977 353.521669 
+L 144.742159 347.609383 
+L 155.310341 337.078124 
+L 165.878523 321.92789 
+L 176.446705 315.399741 
+L 187.014886 317.493676 
+L 197.583068 317.185744 
+L 208.15125 314.475946 
+L 218.719432 312.751529 
+L 229.287614 312.012494 
+L 239.855795 311.027113 
+L 250.423977 309.795386 
+L 260.992159 308.56366 
+L 271.560341 307.331934 
+L 282.128523 312.320425 
+L 292.696705 323.529134 
+L 303.264886 309.856973 
+L 313.833068 271.30394 
+L 324.40125 239.340643 
+L 334.969432 213.967082 
+L 345.537614 187.115449 
+L 356.105795 158.785744 
+L 366.673977 109.639865 
+L 377.242159 39.677812 
+L 387.810341 54.458528 
+L 398.378523 153.982012 
+L 408.946705 273.336288 
+L 419.514886 342.928823 
+L 430.083068 342.928823 
+L 440.65125 312.997875 
+L 451.219432 263.851996 
+L 461.787614 225.422136 
+L 472.355795 228.87097 
+L 482.923977 274.198497 
+L 493.492159 319.895542 
+L 504.060341 349.703318 
+L 514.628523 356.477812 
+L 525.196705 356.477812 
+L 535.764886 356.477812 
+L 546.333068 356.477812 
+L 556.90125 356.477812 
+L 567.469432 356.477812 
+" clip-path="url(#p7de345fdc2)" style="fill: none; stroke: #117733; stroke-width: 2; stroke-linecap: square"/>
+    <defs>
+     <path id="m7797abbc14" d="M 0 3 
+C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
+C 2.683901 1.55874 3 0.795609 3 0 
+C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
+C 1.55874 -2.683901 0.795609 -3 0 -3 
+C -0.795609 -3 -1.55874 -2.683901 -2.12132 -2.12132 
+C -2.683901 -1.55874 -3 -0.795609 -3 0 
+C -3 0.795609 -2.683901 1.55874 -2.12132 2.12132 
+C -1.55874 2.683901 -0.795609 3 0 3 
+z
+"/>
+    </defs>
+    <g clip-path="url(#p7de345fdc2)">
+     <use xlink:href="#m7797abbc14" x="70.764886" y="356.477812" style="fill: #117733"/>
+     <use xlink:href="#m7797abbc14" x="81.333068" y="356.477812" style="fill: #117733"/>
+     <use xlink:href="#m7797abbc14" x="91.90125" y="356.477812" style="fill: #117733"/>
+     <use xlink:href="#m7797abbc14" x="102.469432" y="356.477812" style="fill: #117733"/>
+     <use xlink:href="#m7797abbc14" x="113.037614" y="356.477812" style="fill: #117733"/>
+     <use xlink:href="#m7797abbc14" x="123.605795" y="356.477812" style="fill: #117733"/>
+     <use xlink:href="#m7797abbc14" x="134.173977" y="353.521669" style="fill: #117733"/>
+     <use xlink:href="#m7797abbc14" x="144.742159" y="347.609383" style="fill: #117733"/>
+     <use xlink:href="#m7797abbc14" x="155.310341" y="337.078124" style="fill: #117733"/>
+     <use xlink:href="#m7797abbc14" x="165.878523" y="321.92789" style="fill: #117733"/>
+     <use xlink:href="#m7797abbc14" x="176.446705" y="315.399741" style="fill: #117733"/>
+     <use xlink:href="#m7797abbc14" x="187.014886" y="317.493676" style="fill: #117733"/>
+     <use xlink:href="#m7797abbc14" x="197.583068" y="317.185744" style="fill: #117733"/>
+     <use xlink:href="#m7797abbc14" x="208.15125" y="314.475946" style="fill: #117733"/>
+     <use xlink:href="#m7797abbc14" x="218.719432" y="312.751529" style="fill: #117733"/>
+     <use xlink:href="#m7797abbc14" x="229.287614" y="312.012494" style="fill: #117733"/>
+     <use xlink:href="#m7797abbc14" x="239.855795" y="311.027113" style="fill: #117733"/>
+     <use xlink:href="#m7797abbc14" x="250.423977" y="309.795386" style="fill: #117733"/>
+     <use xlink:href="#m7797abbc14" x="260.992159" y="308.56366" style="fill: #117733"/>
+     <use xlink:href="#m7797abbc14" x="271.560341" y="307.331934" style="fill: #117733"/>
+     <use xlink:href="#m7797abbc14" x="282.128523" y="312.320425" style="fill: #117733"/>
+     <use xlink:href="#m7797abbc14" x="292.696705" y="323.529134" style="fill: #117733"/>
+     <use xlink:href="#m7797abbc14" x="303.264886" y="309.856973" style="fill: #117733"/>
+     <use xlink:href="#m7797abbc14" x="313.833068" y="271.30394" style="fill: #117733"/>
+     <use xlink:href="#m7797abbc14" x="324.40125" y="239.340643" style="fill: #117733"/>
+     <use xlink:href="#m7797abbc14" x="334.969432" y="213.967082" style="fill: #117733"/>
+     <use xlink:href="#m7797abbc14" x="345.537614" y="187.115449" style="fill: #117733"/>
+     <use xlink:href="#m7797abbc14" x="356.105795" y="158.785744" style="fill: #117733"/>
+     <use xlink:href="#m7797abbc14" x="366.673977" y="109.639865" style="fill: #117733"/>
+     <use xlink:href="#m7797abbc14" x="377.242159" y="39.677812" style="fill: #117733"/>
+     <use xlink:href="#m7797abbc14" x="387.810341" y="54.458528" style="fill: #117733"/>
+     <use xlink:href="#m7797abbc14" x="398.378523" y="153.982012" style="fill: #117733"/>
+     <use xlink:href="#m7797abbc14" x="408.946705" y="273.336288" style="fill: #117733"/>
+     <use xlink:href="#m7797abbc14" x="419.514886" y="342.928823" style="fill: #117733"/>
+     <use xlink:href="#m7797abbc14" x="430.083068" y="342.928823" style="fill: #117733"/>
+     <use xlink:href="#m7797abbc14" x="440.65125" y="312.997875" style="fill: #117733"/>
+     <use xlink:href="#m7797abbc14" x="451.219432" y="263.851996" style="fill: #117733"/>
+     <use xlink:href="#m7797abbc14" x="461.787614" y="225.422136" style="fill: #117733"/>
+     <use xlink:href="#m7797abbc14" x="472.355795" y="228.87097" style="fill: #117733"/>
+     <use xlink:href="#m7797abbc14" x="482.923977" y="274.198497" style="fill: #117733"/>
+     <use xlink:href="#m7797abbc14" x="493.492159" y="319.895542" style="fill: #117733"/>
+     <use xlink:href="#m7797abbc14" x="504.060341" y="349.703318" style="fill: #117733"/>
+     <use xlink:href="#m7797abbc14" x="514.628523" y="356.477812" style="fill: #117733"/>
+     <use xlink:href="#m7797abbc14" x="525.196705" y="356.477812" style="fill: #117733"/>
+     <use xlink:href="#m7797abbc14" x="535.764886" y="356.477812" style="fill: #117733"/>
+     <use xlink:href="#m7797abbc14" x="546.333068" y="356.477812" style="fill: #117733"/>
+     <use xlink:href="#m7797abbc14" x="556.90125" y="356.477812" style="fill: #117733"/>
+     <use xlink:href="#m7797abbc14" x="567.469432" y="356.477812" style="fill: #117733"/>
+    </g>
+   </g>
+   <g id="line2d_45">
+    <path d="M 134.173977 356.477812 
+L 134.173977 23.837812 
+" clip-path="url(#p7de345fdc2)" style="fill: none; stroke-dasharray: 5.55,2.4; stroke-dashoffset: 0; stroke: #000000; stroke-width: 1.5"/>
+   </g>
+   <g id="line2d_46">
+    <path d="M 514.628523 356.477812 
+L 514.628523 23.837812 
+" clip-path="url(#p7de345fdc2)" style="fill: none; stroke-dasharray: 5.55,2.4; stroke-dashoffset: 0; stroke: #000000; stroke-width: 1.5"/>
+   </g>
+   <g id="patch_52">
+    <path d="M 45.40125 356.477812 
+L 45.40125 23.837812 
+" style="fill: none; stroke: #1a1a1a; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_53">
+    <path d="M 45.40125 356.477812 
+L 603.40125 356.477812 
+" style="fill: none; stroke: #1a1a1a; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_23">
+    <!-- Comparison of interpolation methods (1h to 15 min) -->
+    <g style="fill: #333333" transform="translate(141.323906 17.837812) scale(0.14 -0.14)">
+     <defs>
+      <path id="DejaVuSans-43" d="M 4122 4306 
+L 4122 3641 
+Q 3803 3938 3442 4084 
+Q 3081 4231 2675 4231 
+Q 1875 4231 1450 3742 
+Q 1025 3253 1025 2328 
+Q 1025 1406 1450 917 
+Q 1875 428 2675 428 
+Q 3081 428 3442 575 
+Q 3803 722 4122 1019 
+L 4122 359 
+Q 3791 134 3420 21 
+Q 3050 -91 2638 -91 
+Q 1578 -91 968 557 
+Q 359 1206 359 2328 
+Q 359 3453 968 4101 
+Q 1578 4750 2638 4750 
+Q 3056 4750 3426 4639 
+Q 3797 4528 4122 4306 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-70" d="M 1159 525 
+L 1159 -1331 
+L 581 -1331 
+L 581 3500 
+L 1159 3500 
+L 1159 2969 
+Q 1341 3281 1617 3432 
+Q 1894 3584 2278 3584 
+Q 2916 3584 3314 3078 
+Q 3713 2572 3713 1747 
+Q 3713 922 3314 415 
+Q 2916 -91 2278 -91 
+Q 1894 -91 1617 61 
+Q 1341 213 1159 525 
+z
+M 3116 1747 
+Q 3116 2381 2855 2742 
+Q 2594 3103 2138 3103 
+Q 1681 3103 1420 2742 
+Q 1159 2381 1159 1747 
+Q 1159 1113 1420 752 
+Q 1681 391 2138 391 
+Q 2594 391 2855 752 
+Q 3116 1113 3116 1747 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-73" d="M 2834 3397 
+L 2834 2853 
+Q 2591 2978 2328 3040 
+Q 2066 3103 1784 3103 
+Q 1356 3103 1142 2972 
+Q 928 2841 928 2578 
+Q 928 2378 1081 2264 
+Q 1234 2150 1697 2047 
+L 1894 2003 
+Q 2506 1872 2764 1633 
+Q 3022 1394 3022 966 
+Q 3022 478 2636 193 
+Q 2250 -91 1575 -91 
+Q 1294 -91 989 -36 
+Q 684 19 347 128 
+L 347 722 
+Q 666 556 975 473 
+Q 1284 391 1588 391 
+Q 1994 391 2212 530 
+Q 2431 669 2431 922 
+Q 2431 1156 2273 1281 
+Q 2116 1406 1581 1522 
+L 1381 1569 
+Q 847 1681 609 1914 
+Q 372 2147 372 2553 
+Q 372 3047 722 3315 
+Q 1072 3584 1716 3584 
+Q 2034 3584 2315 3537 
+Q 2597 3491 2834 3397 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-66" d="M 2375 4863 
+L 2375 4384 
+L 1825 4384 
+Q 1516 4384 1395 4259 
+Q 1275 4134 1275 3809 
+L 1275 3500 
+L 2222 3500 
+L 2222 3053 
+L 1275 3053 
+L 1275 0 
+L 697 0 
+L 697 3053 
+L 147 3053 
+L 147 3500 
+L 697 3500 
+L 697 3744 
+Q 697 4328 969 4595 
+Q 1241 4863 1831 4863 
+L 2375 4863 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-68" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 4863 
+L 1159 4863 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-28" d="M 1984 4856 
+Q 1566 4138 1362 3434 
+Q 1159 2731 1159 2009 
+Q 1159 1288 1364 580 
+Q 1569 -128 1984 -844 
+L 1484 -844 
+Q 1016 -109 783 600 
+Q 550 1309 550 2009 
+Q 550 2706 781 3412 
+Q 1013 4119 1484 4856 
+L 1984 4856 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-29" d="M 513 4856 
+L 1013 4856 
+Q 1481 4119 1714 3412 
+Q 1947 2706 1947 2009 
+Q 1947 1309 1714 600 
+Q 1481 -109 1013 -844 
+L 513 -844 
+Q 928 -128 1133 580 
+Q 1338 1288 1338 2009 
+Q 1338 2731 1133 3434 
+Q 928 4138 513 4856 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-43"/>
+     <use xlink:href="#DejaVuSans-6f" x="69.824219"/>
+     <use xlink:href="#DejaVuSans-6d" x="131.005859"/>
+     <use xlink:href="#DejaVuSans-70" x="228.417969"/>
+     <use xlink:href="#DejaVuSans-61" x="291.894531"/>
+     <use xlink:href="#DejaVuSans-72" x="353.173828"/>
+     <use xlink:href="#DejaVuSans-69" x="394.287109"/>
+     <use xlink:href="#DejaVuSans-73" x="422.070312"/>
+     <use xlink:href="#DejaVuSans-6f" x="474.169922"/>
+     <use xlink:href="#DejaVuSans-6e" x="535.351562"/>
+     <use xlink:href="#DejaVuSans-20" x="598.730469"/>
+     <use xlink:href="#DejaVuSans-6f" x="630.517578"/>
+     <use xlink:href="#DejaVuSans-66" x="691.699219"/>
+     <use xlink:href="#DejaVuSans-20" x="726.904297"/>
+     <use xlink:href="#DejaVuSans-69" x="758.691406"/>
+     <use xlink:href="#DejaVuSans-6e" x="786.474609"/>
+     <use xlink:href="#DejaVuSans-74" x="849.853516"/>
+     <use xlink:href="#DejaVuSans-65" x="889.0625"/>
+     <use xlink:href="#DejaVuSans-72" x="950.585938"/>
+     <use xlink:href="#DejaVuSans-70" x="991.699219"/>
+     <use xlink:href="#DejaVuSans-6f" x="1055.175781"/>
+     <use xlink:href="#DejaVuSans-6c" x="1116.357422"/>
+     <use xlink:href="#DejaVuSans-61" x="1144.140625"/>
+     <use xlink:href="#DejaVuSans-74" x="1205.419922"/>
+     <use xlink:href="#DejaVuSans-69" x="1244.628906"/>
+     <use xlink:href="#DejaVuSans-6f" x="1272.412109"/>
+     <use xlink:href="#DejaVuSans-6e" x="1333.59375"/>
+     <use xlink:href="#DejaVuSans-20" x="1396.972656"/>
+     <use xlink:href="#DejaVuSans-6d" x="1428.759766"/>
+     <use xlink:href="#DejaVuSans-65" x="1526.171875"/>
+     <use xlink:href="#DejaVuSans-74" x="1587.695312"/>
+     <use xlink:href="#DejaVuSans-68" x="1626.904297"/>
+     <use xlink:href="#DejaVuSans-6f" x="1690.283203"/>
+     <use xlink:href="#DejaVuSans-64" x="1751.464844"/>
+     <use xlink:href="#DejaVuSans-73" x="1814.941406"/>
+     <use xlink:href="#DejaVuSans-20" x="1867.041016"/>
+     <use xlink:href="#DejaVuSans-28" x="1898.828125"/>
+     <use xlink:href="#DejaVuSans-31" x="1937.841797"/>
+     <use xlink:href="#DejaVuSans-68" x="2001.464844"/>
+     <use xlink:href="#DejaVuSans-20" x="2064.84375"/>
+     <use xlink:href="#DejaVuSans-74" x="2096.630859"/>
+     <use xlink:href="#DejaVuSans-6f" x="2135.839844"/>
+     <use xlink:href="#DejaVuSans-20" x="2197.021484"/>
+     <use xlink:href="#DejaVuSans-31" x="2228.808594"/>
+     <use xlink:href="#DejaVuSans-35" x="2292.431641"/>
+     <use xlink:href="#DejaVuSans-20" x="2356.054688"/>
+     <use xlink:href="#DejaVuSans-6d" x="2387.841797"/>
+     <use xlink:href="#DejaVuSans-69" x="2485.253906"/>
+     <use xlink:href="#DejaVuSans-6e" x="2513.037109"/>
+     <use xlink:href="#DejaVuSans-29" x="2576.416016"/>
+    </g>
+   </g>
+   <g id="legend_1">
+    <g id="patch_54">
+     <path d="M 450.279375 135.419062 
+L 596.40125 135.419062 
+Q 598.40125 135.419062 598.40125 133.419062 
+L 598.40125 30.837812 
+Q 598.40125 28.837812 596.40125 28.837812 
+L 450.279375 28.837812 
+Q 448.279375 28.837812 448.279375 30.837812 
+L 448.279375 133.419062 
+Q 448.279375 135.419062 450.279375 135.419062 
+z
+" style="fill: #ffffff; opacity: 0.8; stroke: #cccccc; stroke-linejoin: miter"/>
+    </g>
+    <g id="line2d_47">
+     <path d="M 452.279375 36.93625 
+L 462.279375 36.93625 
+L 472.279375 36.93625 
+" style="fill: none; stroke: #ddaa33; stroke-width: 2; stroke-linecap: square"/>
+     <g>
+      <use xlink:href="#me276cf5891" x="462.279375" y="36.93625" style="fill: #ddaa33"/>
+     </g>
+    </g>
+    <g id="text_24">
+     <!-- stepwise -->
+     <g style="fill: #333333" transform="translate(480.279375 40.43625) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-77" d="M 269 3500 
+L 844 3500 
+L 1563 769 
+L 2278 3500 
+L 2956 3500 
+L 3675 769 
+L 4391 3500 
+L 4966 3500 
+L 4050 0 
+L 3372 0 
+L 2619 2869 
+L 1863 0 
+L 1184 0 
+L 269 3500 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-73"/>
+      <use xlink:href="#DejaVuSans-74" x="52.099609"/>
+      <use xlink:href="#DejaVuSans-65" x="91.308594"/>
+      <use xlink:href="#DejaVuSans-70" x="152.832031"/>
+      <use xlink:href="#DejaVuSans-77" x="216.308594"/>
+      <use xlink:href="#DejaVuSans-69" x="298.095703"/>
+      <use xlink:href="#DejaVuSans-73" x="325.878906"/>
+      <use xlink:href="#DejaVuSans-65" x="377.978516"/>
+     </g>
+    </g>
+    <g id="line2d_48">
+     <path d="M 452.279375 51.614375 
+L 462.279375 51.614375 
+L 472.279375 51.614375 
+" style="fill: none; stroke: #004488; stroke-width: 2; stroke-linecap: square"/>
+     <g>
+      <use xlink:href="#m11172a4b8e" x="462.279375" y="51.614375" style="fill: #004488"/>
+     </g>
+    </g>
+    <g id="text_25">
+     <!-- linear_classic -->
+     <g style="fill: #333333" transform="translate(480.279375 55.114375) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-5f" d="M 3263 -1063 
+L 3263 -1509 
+L -63 -1509 
+L -63 -1063 
+L 3263 -1063 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-63" d="M 3122 3366 
+L 3122 2828 
+Q 2878 2963 2633 3030 
+Q 2388 3097 2138 3097 
+Q 1578 3097 1268 2742 
+Q 959 2388 959 1747 
+Q 959 1106 1268 751 
+Q 1578 397 2138 397 
+Q 2388 397 2633 464 
+Q 2878 531 3122 666 
+L 3122 134 
+Q 2881 22 2623 -34 
+Q 2366 -91 2075 -91 
+Q 1284 -91 818 406 
+Q 353 903 353 1747 
+Q 353 2603 823 3093 
+Q 1294 3584 2113 3584 
+Q 2378 3584 2631 3529 
+Q 2884 3475 3122 3366 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-6c"/>
+      <use xlink:href="#DejaVuSans-69" x="27.783203"/>
+      <use xlink:href="#DejaVuSans-6e" x="55.566406"/>
+      <use xlink:href="#DejaVuSans-65" x="118.945312"/>
+      <use xlink:href="#DejaVuSans-61" x="180.46875"/>
+      <use xlink:href="#DejaVuSans-72" x="241.748047"/>
+      <use xlink:href="#DejaVuSans-5f" x="282.861328"/>
+      <use xlink:href="#DejaVuSans-63" x="332.861328"/>
+      <use xlink:href="#DejaVuSans-6c" x="387.841797"/>
+      <use xlink:href="#DejaVuSans-61" x="415.625"/>
+      <use xlink:href="#DejaVuSans-73" x="476.904297"/>
+      <use xlink:href="#DejaVuSans-73" x="529.003906"/>
+      <use xlink:href="#DejaVuSans-69" x="581.103516"/>
+      <use xlink:href="#DejaVuSans-63" x="608.886719"/>
+     </g>
+    </g>
+    <g id="line2d_49">
+     <path d="M 452.279375 66.570625 
+L 462.279375 66.570625 
+L 472.279375 66.570625 
+" style="fill: none; stroke: #bb5566; stroke-width: 2; stroke-linecap: square"/>
+     <g>
+      <use xlink:href="#me1632f8408" x="462.279375" y="66.570625" style="fill: #bb5566"/>
+     </g>
+    </g>
+    <g id="text_26">
+     <!-- linear_time_preserving -->
+     <g style="fill: #333333" transform="translate(480.279375 70.070625) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-76" d="M 191 3500 
+L 800 3500 
+L 1894 563 
+L 2988 3500 
+L 3597 3500 
+L 2284 0 
+L 1503 0 
+L 191 3500 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-67" d="M 2906 1791 
+Q 2906 2416 2648 2759 
+Q 2391 3103 1925 3103 
+Q 1463 3103 1205 2759 
+Q 947 2416 947 1791 
+Q 947 1169 1205 825 
+Q 1463 481 1925 481 
+Q 2391 481 2648 825 
+Q 2906 1169 2906 1791 
+z
+M 3481 434 
+Q 3481 -459 3084 -895 
+Q 2688 -1331 1869 -1331 
+Q 1566 -1331 1297 -1286 
+Q 1028 -1241 775 -1147 
+L 775 -588 
+Q 1028 -725 1275 -790 
+Q 1522 -856 1778 -856 
+Q 2344 -856 2625 -561 
+Q 2906 -266 2906 331 
+L 2906 616 
+Q 2728 306 2450 153 
+Q 2172 0 1784 0 
+Q 1141 0 747 490 
+Q 353 981 353 1791 
+Q 353 2603 747 3093 
+Q 1141 3584 1784 3584 
+Q 2172 3584 2450 3431 
+Q 2728 3278 2906 2969 
+L 2906 3500 
+L 3481 3500 
+L 3481 434 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-6c"/>
+      <use xlink:href="#DejaVuSans-69" x="27.783203"/>
+      <use xlink:href="#DejaVuSans-6e" x="55.566406"/>
+      <use xlink:href="#DejaVuSans-65" x="118.945312"/>
+      <use xlink:href="#DejaVuSans-61" x="180.46875"/>
+      <use xlink:href="#DejaVuSans-72" x="241.748047"/>
+      <use xlink:href="#DejaVuSans-5f" x="282.861328"/>
+      <use xlink:href="#DejaVuSans-74" x="332.861328"/>
+      <use xlink:href="#DejaVuSans-69" x="372.070312"/>
+      <use xlink:href="#DejaVuSans-6d" x="399.853516"/>
+      <use xlink:href="#DejaVuSans-65" x="497.265625"/>
+      <use xlink:href="#DejaVuSans-5f" x="558.789062"/>
+      <use xlink:href="#DejaVuSans-70" x="608.789062"/>
+      <use xlink:href="#DejaVuSans-72" x="672.265625"/>
+      <use xlink:href="#DejaVuSans-65" x="711.128906"/>
+      <use xlink:href="#DejaVuSans-73" x="772.652344"/>
+      <use xlink:href="#DejaVuSans-65" x="824.751953"/>
+      <use xlink:href="#DejaVuSans-72" x="886.275391"/>
+      <use xlink:href="#DejaVuSans-76" x="927.388672"/>
+      <use xlink:href="#DejaVuSans-69" x="986.568359"/>
+      <use xlink:href="#DejaVuSans-6e" x="1014.351562"/>
+      <use xlink:href="#DejaVuSans-67" x="1077.730469"/>
+     </g>
+    </g>
+    <g id="line2d_50">
+     <path d="M 452.279375 81.526875 
+L 462.279375 81.526875 
+L 472.279375 81.526875 
+" style="fill: none; stroke: #117733; stroke-width: 2; stroke-linecap: square"/>
+     <g>
+      <use xlink:href="#m7797abbc14" x="462.279375" y="81.526875" style="fill: #117733"/>
+     </g>
+    </g>
+    <g id="text_27">
+     <!-- linear_solar_radiation -->
+     <g style="fill: #333333" transform="translate(480.279375 85.026875) scale(0.1 -0.1)">
+      <use xlink:href="#DejaVuSans-6c"/>
+      <use xlink:href="#DejaVuSans-69" x="27.783203"/>
+      <use xlink:href="#DejaVuSans-6e" x="55.566406"/>
+      <use xlink:href="#DejaVuSans-65" x="118.945312"/>
+      <use xlink:href="#DejaVuSans-61" x="180.46875"/>
+      <use xlink:href="#DejaVuSans-72" x="241.748047"/>
+      <use xlink:href="#DejaVuSans-5f" x="282.861328"/>
+      <use xlink:href="#DejaVuSans-73" x="332.861328"/>
+      <use xlink:href="#DejaVuSans-6f" x="384.960938"/>
+      <use xlink:href="#DejaVuSans-6c" x="446.142578"/>
+      <use xlink:href="#DejaVuSans-61" x="473.925781"/>
+      <use xlink:href="#DejaVuSans-72" x="535.205078"/>
+      <use xlink:href="#DejaVuSans-5f" x="576.318359"/>
+      <use xlink:href="#DejaVuSans-72" x="626.318359"/>
+      <use xlink:href="#DejaVuSans-61" x="667.431641"/>
+      <use xlink:href="#DejaVuSans-64" x="728.710938"/>
+      <use xlink:href="#DejaVuSans-69" x="792.1875"/>
+      <use xlink:href="#DejaVuSans-61" x="819.970703"/>
+      <use xlink:href="#DejaVuSans-74" x="881.25"/>
+      <use xlink:href="#DejaVuSans-69" x="920.458984"/>
+      <use xlink:href="#DejaVuSans-6f" x="948.242188"/>
+      <use xlink:href="#DejaVuSans-6e" x="1009.423828"/>
+     </g>
+    </g>
+    <g id="line2d_51">
+     <path d="M 452.279375 96.483125 
+L 462.279375 96.483125 
+L 472.279375 96.483125 
+" style="fill: none; stroke-dasharray: 5.55,2.4; stroke-dashoffset: 0; stroke: #000000; stroke-width: 1.5"/>
+    </g>
+    <g id="text_28">
+     <!-- Sunrise (07:30) -->
+     <g style="fill: #333333" transform="translate(480.279375 99.983125) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-75" d="M 544 1381 
+L 544 3500 
+L 1119 3500 
+L 1119 1403 
+Q 1119 906 1312 657 
+Q 1506 409 1894 409 
+Q 2359 409 2629 706 
+Q 2900 1003 2900 1516 
+L 2900 3500 
+L 3475 3500 
+L 3475 0 
+L 2900 0 
+L 2900 538 
+Q 2691 219 2414 64 
+Q 2138 -91 1772 -91 
+Q 1169 -91 856 284 
+Q 544 659 544 1381 
+z
+M 1991 3584 
+L 1991 3584 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-53"/>
+      <use xlink:href="#DejaVuSans-75" x="63.476562"/>
+      <use xlink:href="#DejaVuSans-6e" x="126.855469"/>
+      <use xlink:href="#DejaVuSans-72" x="190.234375"/>
+      <use xlink:href="#DejaVuSans-69" x="231.347656"/>
+      <use xlink:href="#DejaVuSans-73" x="259.130859"/>
+      <use xlink:href="#DejaVuSans-65" x="311.230469"/>
+      <use xlink:href="#DejaVuSans-20" x="372.753906"/>
+      <use xlink:href="#DejaVuSans-28" x="404.541016"/>
+      <use xlink:href="#DejaVuSans-30" x="443.554688"/>
+      <use xlink:href="#DejaVuSans-37" x="507.177734"/>
+      <use xlink:href="#DejaVuSans-3a" x="570.800781"/>
+      <use xlink:href="#DejaVuSans-33" x="604.492188"/>
+      <use xlink:href="#DejaVuSans-30" x="668.115234"/>
+      <use xlink:href="#DejaVuSans-29" x="731.738281"/>
+     </g>
+    </g>
+    <g id="line2d_52">
+     <path d="M 452.279375 111.16125 
+L 462.279375 111.16125 
+L 472.279375 111.16125 
+" style="fill: none; stroke-dasharray: 5.55,2.4; stroke-dashoffset: 0; stroke: #000000; stroke-width: 1.5"/>
+    </g>
+    <g id="text_29">
+     <!-- Sunset (16:30) -->
+     <g style="fill: #333333" transform="translate(480.279375 114.66125) scale(0.1 -0.1)">
+      <use xlink:href="#DejaVuSans-53"/>
+      <use xlink:href="#DejaVuSans-75" x="63.476562"/>
+      <use xlink:href="#DejaVuSans-6e" x="126.855469"/>
+      <use xlink:href="#DejaVuSans-73" x="190.234375"/>
+      <use xlink:href="#DejaVuSans-65" x="242.333984"/>
+      <use xlink:href="#DejaVuSans-74" x="303.857422"/>
+      <use xlink:href="#DejaVuSans-20" x="343.066406"/>
+      <use xlink:href="#DejaVuSans-28" x="374.853516"/>
+      <use xlink:href="#DejaVuSans-31" x="413.867188"/>
+      <use xlink:href="#DejaVuSans-36" x="477.490234"/>
+      <use xlink:href="#DejaVuSans-3a" x="541.113281"/>
+      <use xlink:href="#DejaVuSans-33" x="574.804688"/>
+      <use xlink:href="#DejaVuSans-30" x="638.427734"/>
+      <use xlink:href="#DejaVuSans-29" x="702.050781"/>
+     </g>
+    </g>
+    <g id="patch_55">
+     <path d="M 452.279375 129.339375 
+L 472.279375 129.339375 
+L 472.279375 122.339375 
+L 452.279375 122.339375 
+z
+" style="fill: #d3d3d3"/>
+    </g>
+    <g id="text_30">
+     <!-- Orignal -->
+     <g style="fill: #333333" transform="translate(480.279375 129.339375) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-4f" d="M 2522 4238 
+Q 1834 4238 1429 3725 
+Q 1025 3213 1025 2328 
+Q 1025 1447 1429 934 
+Q 1834 422 2522 422 
+Q 3209 422 3611 934 
+Q 4013 1447 4013 2328 
+Q 4013 3213 3611 3725 
+Q 3209 4238 2522 4238 
+z
+M 2522 4750 
+Q 3503 4750 4090 4092 
+Q 4678 3434 4678 2328 
+Q 4678 1225 4090 567 
+Q 3503 -91 2522 -91 
+Q 1538 -91 948 565 
+Q 359 1222 359 2328 
+Q 359 3434 948 4092 
+Q 1538 4750 2522 4750 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-4f"/>
+      <use xlink:href="#DejaVuSans-72" x="78.710938"/>
+      <use xlink:href="#DejaVuSans-69" x="119.824219"/>
+      <use xlink:href="#DejaVuSans-67" x="147.607422"/>
+      <use xlink:href="#DejaVuSans-6e" x="211.083984"/>
+      <use xlink:href="#DejaVuSans-61" x="274.462891"/>
+      <use xlink:href="#DejaVuSans-6c" x="335.742188"/>
+     </g>
+    </g>
+   </g>
+  </g>
+  <g id="axes_2">
+   <g id="patch_56">
+    <path d="M 104.40125 159.757999 
+L 294.628523 159.757999 
+L 294.628523 52.597813 
+L 104.40125 52.597813 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="patch_57">
+    <path d="M 104.40125 159.757999 
+L 136.105795 159.757999 
+L 136.105795 159.757999 
+L 104.40125 159.757999 
+z
+" clip-path="url(#p68c41be9ea)" style="fill: #d3d3d3"/>
+   </g>
+   <g id="patch_58">
+    <path d="M 136.105795 159.757999 
+L 167.810341 159.757999 
+L 167.810341 150.88957 
+L 136.105795 150.88957 
+z
+" clip-path="url(#p68c41be9ea)" style="fill: #d3d3d3"/>
+   </g>
+   <g id="patch_59">
+    <path d="M 167.810341 159.757999 
+L 199.514886 159.757999 
+L 199.514886 150.88957 
+L 167.810341 150.88957 
+z
+" clip-path="url(#p68c41be9ea)" style="fill: #d3d3d3"/>
+   </g>
+   <g id="patch_60">
+    <path d="M 199.514886 159.757999 
+L 231.219432 159.757999 
+L 231.219432 150.88957 
+L 199.514886 150.88957 
+z
+" clip-path="url(#p68c41be9ea)" style="fill: #d3d3d3"/>
+   </g>
+   <g id="patch_61">
+    <path d="M 231.219432 159.757999 
+L 262.923977 159.757999 
+L 262.923977 150.88957 
+L 231.219432 150.88957 
+z
+" clip-path="url(#p68c41be9ea)" style="fill: #d3d3d3"/>
+   </g>
+   <g id="patch_62">
+    <path d="M 262.923977 159.757999 
+L 294.628523 159.757999 
+L 294.628523 59.249134 
+L 262.923977 59.249134 
+z
+" clip-path="url(#p68c41be9ea)" style="fill: #d3d3d3"/>
+   </g>
+   <g id="patch_63">
+    <path d="M 294.628523 159.757999 
+L 326.333068 159.757999 
+L 326.333068 59.249134 
+L 294.628523 59.249134 
+z
+" clip-path="url(#p68c41be9ea)" style="fill: #d3d3d3"/>
+   </g>
+   <g id="patch_64">
+    <path d="M 104.40125 52.597813 
+L 102.469432 320.75775 
+" style="fill: none; stroke: #000000; stroke-width: 1.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_65">
+    <path d="M 294.628523 159.757999 
+L 165.878523 356.477812 
+" style="fill: none; stroke: #000000; stroke-width: 1.5; stroke-linejoin: miter"/>
+   </g>
+   <g id="matplotlib.axis_3">
+    <g id="xtick_14">
+     <g id="line2d_53">
+      <path d="M 104.40125 159.757999 
+L 104.40125 52.597813 
+" clip-path="url(#p68c41be9ea)" style="fill: none; stroke-dasharray: 2.22,0.96; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.7; stroke-width: 0.6"/>
+     </g>
+     <g id="line2d_54">
+      <g>
+       <use xlink:href="#md816adce21" x="104.40125" y="159.757999" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_31">
+      <!-- 06:45 -->
+      <g style="fill: #1a1a1a" transform="translate(97.811015 183.858671) rotate(-45) scale(0.08 -0.08)">
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-36" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-3a" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-34" x="160.9375"/>
+       <use xlink:href="#DejaVuSans-35" x="224.560547"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_15">
+     <g id="line2d_55">
+      <path d="M 136.105795 159.757999 
+L 136.105795 52.597813 
+" clip-path="url(#p68c41be9ea)" style="fill: none; stroke-dasharray: 2.22,0.96; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.7; stroke-width: 0.6"/>
+     </g>
+     <g id="line2d_56">
+      <g>
+       <use xlink:href="#md816adce21" x="136.105795" y="159.757999" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_32">
+      <!-- 07:00 -->
+      <g style="fill: #1a1a1a" transform="translate(129.51556 183.858671) rotate(-45) scale(0.08 -0.08)">
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-37" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-3a" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-30" x="160.9375"/>
+       <use xlink:href="#DejaVuSans-30" x="224.560547"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_16">
+     <g id="line2d_57">
+      <path d="M 167.810341 159.757999 
+L 167.810341 52.597813 
+" clip-path="url(#p68c41be9ea)" style="fill: none; stroke-dasharray: 2.22,0.96; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.7; stroke-width: 0.6"/>
+     </g>
+     <g id="line2d_58">
+      <g>
+       <use xlink:href="#md816adce21" x="167.810341" y="159.757999" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_33">
+      <!-- 07:15 -->
+      <g style="fill: #1a1a1a" transform="translate(161.220106 183.858671) rotate(-45) scale(0.08 -0.08)">
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-37" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-3a" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-31" x="160.9375"/>
+       <use xlink:href="#DejaVuSans-35" x="224.560547"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_17">
+     <g id="line2d_59">
+      <path d="M 199.514886 159.757999 
+L 199.514886 52.597813 
+" clip-path="url(#p68c41be9ea)" style="fill: none; stroke-dasharray: 2.22,0.96; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.7; stroke-width: 0.6"/>
+     </g>
+     <g id="line2d_60">
+      <g>
+       <use xlink:href="#md816adce21" x="199.514886" y="159.757999" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_34">
+      <!-- 07:30 -->
+      <g style="fill: #1a1a1a" transform="translate(192.924651 183.858671) rotate(-45) scale(0.08 -0.08)">
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-37" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-3a" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-33" x="160.9375"/>
+       <use xlink:href="#DejaVuSans-30" x="224.560547"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_18">
+     <g id="line2d_61">
+      <path d="M 231.219432 159.757999 
+L 231.219432 52.597813 
+" clip-path="url(#p68c41be9ea)" style="fill: none; stroke-dasharray: 2.22,0.96; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.7; stroke-width: 0.6"/>
+     </g>
+     <g id="line2d_62">
+      <g>
+       <use xlink:href="#md816adce21" x="231.219432" y="159.757999" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_35">
+      <!-- 07:45 -->
+      <g style="fill: #1a1a1a" transform="translate(224.629197 183.858671) rotate(-45) scale(0.08 -0.08)">
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-37" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-3a" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-34" x="160.9375"/>
+       <use xlink:href="#DejaVuSans-35" x="224.560547"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_19">
+     <g id="line2d_63">
+      <path d="M 262.923977 159.757999 
+L 262.923977 52.597813 
+" clip-path="url(#p68c41be9ea)" style="fill: none; stroke-dasharray: 2.22,0.96; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.7; stroke-width: 0.6"/>
+     </g>
+     <g id="line2d_64">
+      <g>
+       <use xlink:href="#md816adce21" x="262.923977" y="159.757999" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_36">
+      <!-- 08:00 -->
+      <g style="fill: #1a1a1a" transform="translate(256.333742 183.858671) rotate(-45) scale(0.08 -0.08)">
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-38" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-3a" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-30" x="160.9375"/>
+       <use xlink:href="#DejaVuSans-30" x="224.560547"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_20">
+     <g id="line2d_65">
+      <path d="M 294.628523 159.757999 
+L 294.628523 52.597813 
+" clip-path="url(#p68c41be9ea)" style="fill: none; stroke-dasharray: 2.22,0.96; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.7; stroke-width: 0.6"/>
+     </g>
+     <g id="line2d_66">
+      <g>
+       <use xlink:href="#md816adce21" x="294.628523" y="159.757999" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_37">
+      <!-- 08:15 -->
+      <g style="fill: #1a1a1a" transform="translate(288.038288 183.858671) rotate(-45) scale(0.08 -0.08)">
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-38" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-3a" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-31" x="160.9375"/>
+       <use xlink:href="#DejaVuSans-35" x="224.560547"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_4">
+    <g id="ytick_8">
+     <g id="line2d_67">
+      <path d="M 104.40125 159.757999 
+L 294.628523 159.757999 
+" clip-path="url(#p68c41be9ea)" style="fill: none; stroke-dasharray: 2.22,0.96; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.7; stroke-width: 0.6"/>
+     </g>
+     <g id="line2d_68">
+      <g>
+       <use xlink:href="#m5f231f2fb5" x="104.40125" y="159.757999" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_38">
+      <!-- 0 -->
+      <g style="fill: #1a1a1a" transform="translate(95.81125 162.797374) scale(0.08 -0.08)">
+       <use xlink:href="#DejaVuSans-30"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_9">
+     <g id="line2d_69">
+      <path d="M 104.40125 126.911965 
+L 294.628523 126.911965 
+" clip-path="url(#p68c41be9ea)" style="fill: none; stroke-dasharray: 2.22,0.96; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.7; stroke-width: 0.6"/>
+     </g>
+     <g id="line2d_70">
+      <g>
+       <use xlink:href="#m5f231f2fb5" x="104.40125" y="126.911965" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_39">
+      <!-- 10 -->
+      <g style="fill: #1a1a1a" transform="translate(90.72125 129.95134) scale(0.08 -0.08)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_10">
+     <g id="line2d_71">
+      <path d="M 104.40125 94.065931 
+L 294.628523 94.065931 
+" clip-path="url(#p68c41be9ea)" style="fill: none; stroke-dasharray: 2.22,0.96; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.7; stroke-width: 0.6"/>
+     </g>
+     <g id="line2d_72">
+      <g>
+       <use xlink:href="#m5f231f2fb5" x="104.40125" y="94.065931" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_40">
+      <!-- 20 -->
+      <g style="fill: #1a1a1a" transform="translate(90.72125 97.105306) scale(0.08 -0.08)">
+       <use xlink:href="#DejaVuSans-32"/>
+       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_11">
+     <g id="line2d_73">
+      <path d="M 104.40125 61.219896 
+L 294.628523 61.219896 
+" clip-path="url(#p68c41be9ea)" style="fill: none; stroke-dasharray: 2.22,0.96; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.7; stroke-width: 0.6"/>
+     </g>
+     <g id="line2d_74">
+      <g>
+       <use xlink:href="#m5f231f2fb5" x="104.40125" y="61.219896" style="fill: #1a1a1a; stroke: #1a1a1a; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_41">
+      <!-- 30 -->
+      <g style="fill: #1a1a1a" transform="translate(90.72125 64.259271) scale(0.08 -0.08)">
+       <use xlink:href="#DejaVuSans-33"/>
+       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <g id="line2d_75">
+    <path d="M 104.40125 159.757999 
+L 136.105795 150.88957 
+L 167.810341 150.88957 
+L 199.514886 150.88957 
+L 231.219432 150.88957 
+L 262.923977 59.249134 
+L 294.628523 59.249134 
+" clip-path="url(#p68c41be9ea)" style="fill: none; stroke: #ddaa33; stroke-width: 2; stroke-linecap: square"/>
+    <g clip-path="url(#p68c41be9ea)">
+     <use xlink:href="#me276cf5891" x="104.40125" y="159.757999" style="fill: #ddaa33"/>
+     <use xlink:href="#me276cf5891" x="136.105795" y="150.88957" style="fill: #ddaa33"/>
+     <use xlink:href="#me276cf5891" x="167.810341" y="150.88957" style="fill: #ddaa33"/>
+     <use xlink:href="#me276cf5891" x="199.514886" y="150.88957" style="fill: #ddaa33"/>
+     <use xlink:href="#me276cf5891" x="231.219432" y="150.88957" style="fill: #ddaa33"/>
+     <use xlink:href="#me276cf5891" x="262.923977" y="59.249134" style="fill: #ddaa33"/>
+     <use xlink:href="#me276cf5891" x="294.628523" y="59.249134" style="fill: #ddaa33"/>
+    </g>
+   </g>
+   <g id="line2d_76">
+    <path d="M 104.40125 153.106677 
+L 136.105795 150.88957 
+L 167.810341 127.979461 
+L 199.514886 105.069352 
+L 231.219432 82.159243 
+L 262.923977 59.249134 
+L 294.628523 52.597813 
+" clip-path="url(#p68c41be9ea)" style="fill: none; stroke: #004488; stroke-width: 2; stroke-linecap: square"/>
+    <g clip-path="url(#p68c41be9ea)">
+     <use xlink:href="#m11172a4b8e" x="104.40125" y="153.106677" style="fill: #004488"/>
+     <use xlink:href="#m11172a4b8e" x="136.105795" y="150.88957" style="fill: #004488"/>
+     <use xlink:href="#m11172a4b8e" x="167.810341" y="127.979461" style="fill: #004488"/>
+     <use xlink:href="#m11172a4b8e" x="199.514886" y="105.069352" style="fill: #004488"/>
+     <use xlink:href="#m11172a4b8e" x="231.219432" y="82.159243" style="fill: #004488"/>
+     <use xlink:href="#m11172a4b8e" x="262.923977" y="59.249134" style="fill: #004488"/>
+     <use xlink:href="#m11172a4b8e" x="294.628523" y="52.597813" style="fill: #004488"/>
+    </g>
+   </g>
+   <g id="line2d_77">
+    <path d="M 104.40125 156.432338 
+L 136.105795 154.215231 
+L 167.810341 151.998124 
+L 199.514886 139.434515 
+L 231.219432 116.524407 
+L 262.923977 93.614298 
+L 294.628523 70.704189 
+" clip-path="url(#p68c41be9ea)" style="fill: none; stroke: #bb5566; stroke-width: 2; stroke-linecap: square"/>
+    <g clip-path="url(#p68c41be9ea)">
+     <use xlink:href="#me1632f8408" x="104.40125" y="156.432338" style="fill: #bb5566"/>
+     <use xlink:href="#me1632f8408" x="136.105795" y="154.215231" style="fill: #bb5566"/>
+     <use xlink:href="#me1632f8408" x="167.810341" y="151.998124" style="fill: #bb5566"/>
+     <use xlink:href="#me1632f8408" x="199.514886" y="139.434515" style="fill: #bb5566"/>
+     <use xlink:href="#me1632f8408" x="231.219432" y="116.524407" style="fill: #bb5566"/>
+     <use xlink:href="#me1632f8408" x="262.923977" y="93.614298" style="fill: #bb5566"/>
+     <use xlink:href="#me1632f8408" x="294.628523" y="70.704189" style="fill: #bb5566"/>
+    </g>
+   </g>
+   <g id="line2d_78">
+    <path d="M 104.40125 159.757999 
+L 136.105795 159.757999 
+L 167.810341 159.757999 
+L 199.514886 150.88957 
+L 231.219432 133.152711 
+L 262.923977 101.558932 
+L 294.628523 56.108232 
+" clip-path="url(#p68c41be9ea)" style="fill: none; stroke: #117733; stroke-width: 2; stroke-linecap: square"/>
+    <g clip-path="url(#p68c41be9ea)">
+     <use xlink:href="#m7797abbc14" x="104.40125" y="159.757999" style="fill: #117733"/>
+     <use xlink:href="#m7797abbc14" x="136.105795" y="159.757999" style="fill: #117733"/>
+     <use xlink:href="#m7797abbc14" x="167.810341" y="159.757999" style="fill: #117733"/>
+     <use xlink:href="#m7797abbc14" x="199.514886" y="150.88957" style="fill: #117733"/>
+     <use xlink:href="#m7797abbc14" x="231.219432" y="133.152711" style="fill: #117733"/>
+     <use xlink:href="#m7797abbc14" x="262.923977" y="101.558932" style="fill: #117733"/>
+     <use xlink:href="#m7797abbc14" x="294.628523" y="56.108232" style="fill: #117733"/>
+    </g>
+   </g>
+   <g id="line2d_79">
+    <path d="M 199.514886 159.757999 
+L 199.514886 52.597813 
+" clip-path="url(#p68c41be9ea)" style="fill: none; stroke-dasharray: 5.55,2.4; stroke-dashoffset: 0; stroke: #000000; stroke-width: 1.5"/>
+   </g>
+   <g id="patch_66">
+    <path d="M 104.40125 159.757999 
+L 104.40125 52.597813 
+" style="fill: none; stroke: #1a1a1a; stroke-width: 2.5; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_67">
+    <path d="M 104.40125 159.757999 
+L 294.628523 159.757999 
+" style="fill: none; stroke: #1a1a1a; stroke-width: 2.5; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="p7de345fdc2">
+   <rect x="45.40125" y="23.837812" width="558" height="332.64"/>
+  </clipPath>
+  <clipPath id="p68c41be9ea">
+   <rect x="104.40125" y="52.597813" width="190.227273" height="107.160187"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/docs/resie_input_file_format.md
+++ b/docs/resie_input_file_format.md
@@ -49,6 +49,7 @@ The overall structure of the project file is split into three general sections a
         "TST_01_HZG_01_CHP": ["m_h_w_ht1 OUT"],
         ...
     },
+    "csv_output_weather": true,
     "output_plot_file": "./output/output_plot.html",
     "output_plot_time_unit": "date",
 	"output_plot": {
@@ -59,13 +60,15 @@ The overall structure of the project file is split into three general sections a
 			"scale_factor": 0.001
 		},
 		...
-	}
+	},
+    "plot_weather_data": true,
 },
 ```
 
 * `csv_output_file` (`String`): (Optional) File path to where the CSV output will be written. Defaults to `./output/out.csv`.
 * `csv_time_unit` (`String`): Time unit for the time stamp of the CSV file. Has to be one of: `seconds`, `minutes`, `hours`, `date`. Defaults to `date`.
 * `csv_output_keys` (`Union{String, Dict{String, List{String}}}`): Specifications for CSV output file. See [section "Output specification (CSV-file)"](resie_input_file_format.md#output-specification-csv-file) for details.
+* `csv_output_weather` (`Boolean`): (Optional) If true, the weather data read in from a given weather file is exported to the CSV file. Defaults to `false`.
 * `auxiliary_info` (`Boolean`): If true, will write additional information about the current run to a markdown file.
 * `auxiliary_info_file` (`String`): (Optional) File path to where the additional information will be written. Defaults to `./output/auxiliary_info.md`.
 * `auxiliary_plots` (`Boolean`): If true, ReSiE will create additional plots of components, if available (currently only available for geothermal probe). Defaults to `false`.
@@ -76,6 +79,8 @@ The overall structure of the project file is split into three general sections a
 * `output_plot_file`: (Optional) File path to where the output line plot will be written. Defaults to `./output/output_plot.html`.
 * `output_plot_time_unit`: Unit for x-axis of output plot. Can be one of `seconds`, `minutes`, `hours`, `date`. Defaults to `date`. Note that the plotted energies always refer to the simulation time step and not to the unit specified here!
 * `output_plot` (`Union{String, Dict{Int, Dict{String, Any}}`): Specifications for output line plot. See [section "Output specification (interactive .html plot)"](resie_input_file_format.md#output-specification-interactive-html-plot) for details.
+* `plot_weather_data` (`Boolean`): (Optional) If true, the weather data read in from a given weather file is plotted to the line plot. Defaults to `false`.
+
 
 ### Output specification (Sankey)
 
@@ -113,6 +118,8 @@ The keys of this map must correspond exactly to the UAC of the components define
 
 The second part of the entry describes which of the available variables of the component the desired output is. For most components either `IN` (input) and/or `OUT` (output) is available, which additional variables depending on the type. For example, storage components often have the variable `Load` available, which corresponds to the amount of energy stored in the component. Also, most of the transformer and storage components have the output variable `Losses`, which represents the total energy losses, while some components have an additional splitting into different media of the losses, like `Losses_heat` or `Losses_hydrogen`.  These additional variables do not have a medium associated with them and hence should be declared with their name alone. For details, which output channels are available for each component, see the [chapter on the component parameters](resie_component_parameters.md). 
 
+To output the weather data read in from a provided weather file, the flag `csv_output_weather` in the `io_settings` can be set to `true`.
+
 ### Output specification (interactive .html plot)
 
 The output values of each component can be plotted in an interactive HTML-based line plot. `output_plot` can either be ```"all"```, ```"nothing"``` or a list of entries as described below. For ```"output_plot": "all"```, all possible output channels of all components will be plotted in the line plot, while for ```"nothing"``` no plot will be created. Note that for ```"output_plot": "all"```, the unit of each output is not specified as well as there is no `scale_factor` as for custon defined outputs. 
@@ -138,6 +145,8 @@ To define a custom plot, use the following syntax:
 ```
 The name of each object of this entry is a consecutive number starting from 1. Each value is a list of objects containing the fields ```"key"``` that has to match the UAC-name of the component and the medium of the requested data, ```"axis"``` that can be either "left" or "right" to choose on which y-axis the data should be plotted, ```"unit"``` as string displayed in the label of the output and ```"scale_factor"``` to scale the output data. Differing from ```"csv_output_keys"```, here every output UAC has to be set as individual entry. Compare also to the example given above that displays the input and output thermal energy of one heat pump. Note that ```"unit"``` refers to the scaled data! 
 
+To plot the weather data read in from a provided weather file to the interactive HTML plot, the flag `plot_weather_data` in the `io_settings` can be set to `true`. Here, no scaling or other settings can yet be made.
+
 The results will be saved by default in `./output/output_plot.html`. The plot can be opened with any browser and offers some interactivity like zooming or hiding data series.
 
 ## Simulation parameters
@@ -149,6 +158,8 @@ The results will be saved by default in `./output/output_plot.html`. The plot ca
     "time_step": 60,
     "time_step_unit": "minutes",
     "weather_file_path": "./path/to/dat/or/epw/wather_file.epw",
+    "weather_interpolation_type_general": "stepwise",
+    "weather_interpolation_type_solar": "linear_solar_radiation",
     "latitude": 48.755749,
     "longitude": 9.190182, 
 },
@@ -160,6 +171,8 @@ The results will be saved by default in `./output/output_plot.html`. The plot ca
 * `time_step` (`Integer`): Time step in the given `time_step_unit` format. Defaults to 900 seconds.
 * `time_step_unit` (`String`): Format of the `time_step`, can be one of `seconds`, `minutes`, `hours`.
 * `weather_file_path` (`String`): (Optional) File path to the project-wide weather file. Can either be an EnergyPlus Weather File (EPW, time step has to be one hour, without leap day or DST) or a .dat file from the DWD (see [https://kunden.dwd.de/obt/](https://kunden.dwd.de/obt/), free registration is required). See the component parameters on how to link weather file data to a component.
+* `weather_interpolation_type_general` (`String`): (Optional) Interpolation type for weather data from weather file, except for solar radiation data. Can be one of: `"stepwise"`, `"linear_classic"`, `"linear_time_preserving"`, `"linear_solar_radiation"`. Defaults to "linear_classic". For details, see [this chapter](resie_time_definition.md#aggregation-segmentation-and-time-shifting-of-profile-data).
+* `weather_interpolation_type_solar` (`String`): (Optional) Interpolation method for solar radiation data from weather file. Can be one of: `"stepwise"`, `"linear_classic"`, `"linear_time_preserving"`, `"linear_solar_radiation"`. Defaults to "linear_solar_radiation". For details, see [this chapter](resie_time_definition.md#aggregation-segmentation-and-time-shifting-of-profile-data).
 * `latitude` (`Float`): The latitude of the location in WGS84. If given, it overwrites the coordinates read out of the weather file!
 * `longitude` (`Float`): The longitude of location in WGS84. If given, it overwrites the coordinates read out of the weather file!
 
@@ -309,7 +322,7 @@ Ahead of the data, a block of metadata describes important information and param
 * `timestamp_format` (`String`): The format specifier for the datetime index (only for `startdate_timestamp` or `datestamp`). Can be `seconds`, `minutes`, `hours` or a custom datetime format. See table below for details on the datetime formatter.
 * `time_zone` (`String`): A timezone in [IANA format](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) that applies for the datetime index. Must only be given if daylight saving is included in the `datestamp`. Only for `datestamp`.
 * `time_shift_seconds` (`Integer`, optional): Specifies the number of seconds by which to shift the timestamps of a profile. A positive value shifts the timestamps forward in time, meaning a specific value will align with an earlier time step. Conversely, a negative value shifts the timestamps backward, aligning a specific value with a later time step. If the timestamps do not align with the simulation timestep after the shift, the values will be linearly interpolated. This can be useful, for example, if a profile does not align with the convention that values represent the timespan following the given time step. If this results in a missing value at the beginning or end of a profile, the last or first value is duplicated. Attention: The linear interpolation may lead to a different sum and mean of the converted profile compared to the original one!
-* `use_linear_segmentation` (`Bool`, optional): A flag that specifies whether to use linear interpolation (`true`) or step interpolation (`false`) to fill values for a given profile at intermediate timesteps during segmentation. Defaults to `false`. Attention: Linear interpolation may lead to a different sum and mean of the converted profile compared to the original one! If you want to maintain the integral of a profile exactly, use step interpolation!
+* `interpolation_type` (`String`, optional): Specifies the interpolation type for profile segmentation. Can be one of: `"stepwise"`, `"linear_classic"`, `"linear_time_preserving"`, `"linear_solar_radiation"`. Defaults to "stepwise". Attention: Classic and time_preserving linear interpolation may lead to a different sum and mean of the converted profile in every time step compared to the original one! If you want to maintain the integral of a profile exactly, use step interpolation! A description and comparison of the different methods is given in [this chapter](resie_time_definition.md#aggregation-segmentation-and-time-shifting-of-profile-data).
 
 The format specifier for a custom datetime format can be composed from the table below, that holds a selection of the possible format types that are defined by the Julia *Dates* module:
   

--- a/docs/resie_input_file_format.md
+++ b/docs/resie_input_file_format.md
@@ -162,6 +162,7 @@ The results will be saved by default in `./output/output_plot.html`. The plot ca
     "weather_interpolation_type_solar": "linear_solar_radiation",
     "latitude": 48.755749,
     "longitude": 9.190182, 
+    "time_zone": 1.0
 },
 ```
 
@@ -175,6 +176,7 @@ The results will be saved by default in `./output/output_plot.html`. The plot ca
 * `weather_interpolation_type_solar` (`String`): (Optional) Interpolation method for solar radiation data from weather file. Can be one of: `"stepwise"`, `"linear_classic"`, `"linear_time_preserving"`, `"linear_solar_radiation"`. Defaults to "linear_solar_radiation". For details, see [this chapter](resie_time_definition.md#aggregation-segmentation-and-time-shifting-of-profile-data).
 * `latitude` (`Float`): The latitude of the location in WGS84. If given, it overwrites the coordinates read out of the weather file!
 * `longitude` (`Float`): The longitude of location in WGS84. If given, it overwrites the coordinates read out of the weather file!
+* `time_zone` (`Float`): The time zone used in the current simulation in relation to UTC. If given, it overwrites the coordinates read out of the weather file! DWD-dat files are assumed to be in GMT+1.
 
 **A note on time:** Internally, the simulation engine works with timestamps in seconds relative to the reference point specified as `start`. To ensure consistent data, all specified profiles are read in with a predefined or created datetime index, which must cover the simulation period from `start` to `end` (inclusive). Internally, all profile datetime indexes are converted to local standard time without daylight savings, which is also used for the output timestamp! Leap days are filtered out in all inputs and outputs to ensure consistency with weather data sets. See the chapter profiles below and [Time, time zones and weather files](resie_time_definition.md) for more information.
 

--- a/docs/resie_input_file_format.md
+++ b/docs/resie_input_file_format.md
@@ -145,7 +145,7 @@ To define a custom plot, use the following syntax:
 ```
 The name of each object of this entry is a consecutive number starting from 1. Each value is a list of objects containing the fields ```"key"``` that has to match the UAC-name of the component and the medium of the requested data, ```"axis"``` that can be either "left" or "right" to choose on which y-axis the data should be plotted, ```"unit"``` as string displayed in the label of the output and ```"scale_factor"``` to scale the output data. Differing from ```"csv_output_keys"```, here every output UAC has to be set as individual entry. Compare also to the example given above that displays the input and output thermal energy of one heat pump. Note that ```"unit"``` refers to the scaled data! 
 
-To plot the weather data read in from a provided weather file to the interactive HTML plot, the flag `plot_weather_data` in the `io_settings` can be set to `true`. Here, no scaling or other settings can yet be made.
+To plot the weather data read in from a provided weather file to the interactive HTML plot, the flag `plot_weather_data` in the `io_settings` can be set to `true`. Here, no scaling or other settings can be made yet.
 
 The results will be saved by default in `./output/output_plot.html`. The plot can be opened with any browser and offers some interactivity like zooming or hiding data series.
 

--- a/docs/resie_time_definition.md
+++ b/docs/resie_time_definition.md
@@ -54,7 +54,7 @@ ReSiE automatically adjusts the time series data of profiles to match the simula
 time step to make the values be measured at the time indicated. After the linear interpolation to a 
 finer time step, the data is shifted back by 1/2 a time step to meet the required definition 
 of the values representing the following time step. This should be used for time-critical data as it satisfies the original 
-definition of time. But, this method will strengthen peaks and drops in the data more than the classic interpolation.
+definition of time. But, this method will reduce the amplitude of peaks and drops in the data more than the classic interpolation.
 - `"linear_solar_radiation"` interpolation uses a method described in the paper by McDowell et. al[^McDowell2018].
 It is an interpolation with a correction factor to keep the sum of the interpolated values equal to the sum of the
 original values **in every hour** and at the same time to predict a realistic course of the radiation between the given hourly values.

--- a/docs/resie_time_definition.md
+++ b/docs/resie_time_definition.md
@@ -49,21 +49,21 @@ ReSiE automatically adjusts the time series data of profiles to match the simula
 
 - `"stepwise"` means, the value given at a timestamp is distributed evenly or copied across the new smaller timestamps. 
 - `"linear_classic"` interpolates the given values from the original timestamps linearly to the new timestamps, using the
-   values and the correspinding given timestamps indicating the begin of the covered timespan as basis.
+   values and the corresponding given timestamps, indicating the begin of the covered timespan, as basis.
 - `"linear_time_preserving"` interpolates the data by first shifting the data by half the original 
 time step to make the values be measured at the time indicated. After the linear interpolation to a 
 finer time step, the data is shifted back by 1/2 a time step to meet the required definition 
-of the values representing the following time step. This should be used for time-critic data as it satisfies the original 
-definition of time. But, this method will cut peaks and valleys in the data more than the classic interpolation.
+of the values representing the following time step. This should be used for time-critical data as it satisfies the original 
+definition of time. But, this method will strengthen peaks and drops in the data more than the classic interpolation.
 - `"linear_solar_radiation"` interpolation uses a method described in the paper by McDowell et. al[^McDowell2018].
 It is an interpolation with a correction factor to keep the sum of the interpolated values equal to the sum of the
 original values **in every hour** and at the same time to predict a realistic course of the radiation between the given hourly values.
-It also cuts radiation before sunrise and after sunset. This is also used in TRNSYS 18, but the methods can shows "wavy" curves 
+It also cuts radiation before sunrise and after sunset. This is also used in TRNSYS 18, but the method can show "wavy" curves 
 as result and can only be used for the segmentation of hourly data.
 
 [^McDowell2018]: T. McDowell, S. Letellier-Duchesne, M. Kummert (2018): "A New Method for Determining Sub-hourly Solar Radiation from Hourly Data" 
 
-All  methods handle intensive and extensive values appropriately. The following figure compares the four methods to illustrate their results
+All methods handle intensive and extensive values appropriately. The following figure compares the four methods to illustrate their results
 when segmentating hourly data (light grey) to a 15 minute timestep. Note that each dot at a given time represents the sum/mean of the upcoming time step:
 
 <center>![Profile segmentaton methods](fig/250224_segmentation_algorithms.svg)</center>

--- a/docs/resie_time_definition.md
+++ b/docs/resie_time_definition.md
@@ -74,7 +74,7 @@ For a **time shift** to align profile timestamps with the simulation timestamps 
 
 If some timestamps are missing at the beginning or end of the profile during the conversion process, and these are needed to compute the first or last value of the new profile, the values from the original profile are duplicated to fill in the gaps. In this case, an info log message is generated.
 
-**Note**: Linear interpolation for time shifts and segmentation may smoothen the original profile, potentially changing the total sum/mean of the profile. If preserving the original sum/mean is crucial, use stepwise interpolation instead and no time shift. The difference is illustrated in the figures below. The first shows the different integral of the linear and stepwise segmentation methods, the second the smoothing effect of a time shift.
+**Note**: Linear interpolation for time shifts and segmentation may smoothen the original profile, potentially changing the total sum/mean of the profile. If preserving the original sum/mean is crucial, use stepwise interpolation instead and no time shift. The difference is illustrated in the figures below. The first shows the different integral of the `linear_classic` and `stepwise` segmentation methods, the second the smoothing effect of a time shift.
 
 <center>![Profile segmentaton methods](fig/240905_profile_segmentation_methods_comparison.jpg)</center>
 


### PR DESCRIPTION
Changes for ReSiE PR #67 "Improve weather and profile handling" with the following changes:

- add the possibility to output the weather data from EPW and dat-files to the lineplot (`io_settings: "plot_weather_data"`) and CSV output (`io_settings: "csv_output_weather"`)
- add two more interpolation methods for segmentation of data. Now the following methods are available: 
   - `"stepwise"`
   - `"linear_classic"`
   - `"linear_time_preserving"`
   - `"linear_solar_radiation"`. 
  They can be specified in the profile file header (`"interpolation_type"`) and for weather solar data (`simulation_parameters: "weather_interpolation_type_solar"`)  and other weather data (`simulation_parameters: "weather_interpolation_type_general"`) separately. 
- the time zone can now be specified in the simulation_parameters using `"time_zone"` to overwrite the time zone provided by the weather file.
- change the internal handling of profile time step during segmentation and aggregation from seconds to milliseconds
- add tests for segmentation algorithms